### PR TITLE
fix: add browseUrl field to Project

### DIFF
--- a/snyk/models.py
+++ b/snyk/models.py
@@ -421,6 +421,7 @@ class Project(DataClassJSONMixin):
     testFrequency: str
     totalDependencies: int
     lastTestedDate: str
+    browseUrl: str
     issueCountsBySeverity: IssueCounts
     imageTag: Optional[str] = None
     imageId: Optional[str] = None

--- a/snyk/test_client.py
+++ b/snyk/test_client.py
@@ -104,6 +104,7 @@ class TestSnykClient(object):
                     "totalDependencies": 438,
                     "issueCountsBySeverity": {"low": 8, "high": 13, "medium": 15},
                     "lastTestedDate": "2019-02-05T06:21:00.000Z",
+                    "browseUrl": "https://app.snyk.io/org/pysnyk-test-org/project/6d5813be-7e6d-4ab8-80c2-1e3e2a454545",
                 }
             ]
         }

--- a/snyk/test_models.py
+++ b/snyk/test_models.py
@@ -180,6 +180,7 @@ class TestProject(TestModels):
             totalDependencies=438,
             issueCountsBySeverity={"low": 8, "high": 13, "medium": 15},
             lastTestedDate="2019-02-05T06:21:00.000Z",
+            browseUrl="https://app.snyk.io/org/pysnyk-test-org/project/6d5813be-7e6d-4ab8-80c2-1e3e2a454545",
             organization=organization,
         )
 


### PR DESCRIPTION
The `browseUrl` field has been added to the project APIs so adding this field to correspond.