### PR TITLE
Add explicit manifest support to the high-level import method

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,6 +108,12 @@ org.import_project("github.com/user/project@branch")
 org.import_project("docker.io/repository:tag")
 ```
 
+If you are targetting a specific manifest file or files you can pass those as an optional argument, for instance:
+
+```python
+org.import_project("github.com/user/project@branch", files=["Gemfile.lock"])
+```
+
 This method currently only supports importing projects from GitHub and Docker Hub. For other integrations you will need to grab the lower-level `snyk.models.Integration` object from the `snyk.models.Organization.integrations` manager noted above. Other services will be added to this API soon.
 
 

--- a/poetry.lock
+++ b/poetry.lock
@@ -217,7 +217,7 @@ description = "pytest: simple powerful testing with Python"
 name = "pytest"
 optional = false
 python-versions = ">=3.5"
-version = "5.2.1"
+version = "5.2.2"
 
 [package.dependencies]
 atomicwrites = ">=1.0"
@@ -419,7 +419,7 @@ version = "0.6.0"
 more-itertools = "*"
 
 [metadata]
-content-hash = "70c5544c4dae160d3839a28ba5f16ba102e50ede37fe163ba4e0fe2a1205d03d"
+content-hash = "e21bb72b452b988ed62116b2dfa6a157a9f01555c07d620ee8ee71b51004258d"
 python-versions = "^3.7"
 
 [metadata.hashes]
@@ -445,7 +445,7 @@ pluggy = ["0db4b7601aae1d35b4a033282da476845aa19185c1e6964b25cf324b5e4ec3e6", "f
 poetry-version = ["75d3f7ae3ede0539529a81170e77441bc753827f5a1de20ec8174877471d8eaf", "d0edca96a5798e668fb81cdc5941975d1cb0b6020df4b95464b2939605654617"]
 py = ["64f65755aee5b381cea27766a3a147c3f15b9b6b9ac88676de66ba2ae36793fa", "dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"]
 pyparsing = ["6f98a7b9397e206d78cc01df10131398f1c8b8510a2f4d97d9abd82e1aacdd80", "d9338df12903bbf5d65a0e4e87c2161968b10d2e489652bb47001d82a9b028b4"]
-pytest = ["7e4800063ccfc306a53c461442526c5571e1462f61583506ce97e4da6a1d88c8", "ca563435f4941d0cb34767301c27bc65c510cb82e90b9ecf9cb52dc2c63caaa0"]
+pytest = ["27abc3fef618a01bebb1f0d6d303d2816a99aa87a5968ebc32fe971be91eb1e6", "58cee9e09242937e136dbb3dab466116ba20d6b7828c7620f23947f37eb4dae4"]
 pytest-black = ["75bbeccfe23442a190164c0bf202d7498df25451fa4177b781cee20183e7fc0d"]
 pytest-cov = ["cc6742d8bac45070217169f5f72ceee1e0e55b0221f54bcf24845972d3a47f2b", "cdbdef4f870408ebdbfeb44e63e07eb18bb4619fae852f6e760645fa36172626"]
 pytest-isort = ["3be60e0de277b420ff89303ca6494320c41f7819ffa898756b90ef976e4c636a", "4bfee60dad1870b51700d55a85f5ceda766bd9d3d2878c1bbabee80e61b1be1a"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ pytest = "^5.0"
 pytest-black = "^0.3.7"
 pytest-cov = "^2.7"
 pytest-mypy = "^0.4.0"
-requests-mock = "^1.6"
+requests-mock = "^1.7"
 xlsxwriter = "^1.1.8"
 pytest-isort = "^0.3.1"
 

--- a/snyk/models.py
+++ b/snyk/models.py
@@ -114,7 +114,7 @@ class Organization(DataClassJSONMixin):
     and files, and better errors, would be required.
     """
 
-    def import_project(self, url) -> bool:
+    def import_project(self, url, files: Optional[List[str]] = None) -> bool:
         try:
             components = url.split("/")
             service = components[0]
@@ -144,9 +144,12 @@ class Organization(DataClassJSONMixin):
                     name
                 )
             else:
-                return self.integrations.filter(name=integration_name)[0].import_git(
-                    owner, name, branch
-                )
+                integration = self.integrations.filter(name=integration_name)[0]
+
+                if files:
+                    return integration.import_git(owner, name, branch, files)
+                else:
+                    return integration.import_git(owner, name, branch)
 
         except KeyError:
             raise SnykError

--- a/snyk/test_models.py
+++ b/snyk/test_models.py
@@ -165,6 +165,46 @@ class TestOrganization(TestModels):
         with pytest.raises(SnykError):
             organization.test_rubygem("puppet", "4.0.0")
 
+    def test_import_git(self, organization, requests_mock):
+        integration_matcher = re.compile("integrations$")
+        import_matcher = re.compile("import$")
+        output = {"github": "not-a-real-id"}
+        requests_mock.get(integration_matcher, json=output)
+        requests_mock.post(import_matcher)
+        gh = organization.integrations.first()
+        assert gh.import_git("org", "repo", "branch")
+        payload = requests_mock.last_request.json()
+        assert len(payload["files"]) == 0
+        assert payload["target"]["branch"] == "branch"
+        assert payload["target"]["name"] == "repo"
+        assert payload["target"]["owner"] == "org"
+
+    def test_import_project(self, organization, requests_mock):
+        integration_matcher = re.compile("integrations$")
+        import_matcher = re.compile("import$")
+        output = {"github": "not-a-real-id"}
+        requests_mock.get(integration_matcher, json=output)
+        requests_mock.post(import_matcher)
+        assert organization.import_project("github.com/org/repo")
+        payload = requests_mock.last_request.json()
+        assert len(payload["files"]) == 0
+        assert payload["target"]["branch"] == "master"
+        assert payload["target"]["name"] == "repo"
+        assert payload["target"]["owner"] == "org"
+
+    def test_import_project_with_files(self, organization, requests_mock):
+        integration_matcher = re.compile("integrations$")
+        import_matcher = re.compile("import$")
+        output = {"github": "not-a-real-id"}
+        requests_mock.get(integration_matcher, json=output)
+        requests_mock.post(import_matcher)
+        assert organization.import_project(
+            "github.com/org/repo", files=["Gemfile.lock"]
+        )
+        payload = requests_mock.last_request.json()
+        assert len(payload["files"]) == 1
+        assert payload["files"][0]["path"] == "Gemfile.lock"
+
 
 class TestProject(TestModels):
     @pytest.fixture


### PR DESCRIPTION
Previously Snyk would detect a single manifest, which for multi-manifest
projects makes this method unsuitable. The changes support a backwards
compatible addition to the API to specify one or more manifest files.

This area of the code was also one of the last lacking tests. This
commit also adds some around the main methods, with a pattern that can
be expanded across the other import methods.