### PR TITLE
Added support for tags on projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ client.projects.all()
 
 The `snyk.models.Project` object has the following useful properties and methods:
 
-* `delete()` - deletes the project in question. We careful as this will delete all associated data too
+* `delete()` - deletes the project in question. Be careful as this will delete all associated data too
 * `dependencies` - returns a Manager for packages in use in this project
 * `dependency_graph` - returns a `snyk.models.DependencyGraph` object which represents the full dependency graph of package dependencies
 * `ignores` - returns a Manager for ignore rules set on the project
@@ -91,8 +91,14 @@ The `snyk.models.Project` object has the following useful properties and methods
 * `jira_issues` - returns a Manager with access to any associated Jira issues
 * `licenses` - returns a Manager for licenses currently in use by this project
 * `settings` - returns a Manager for interacting with the current project settings  
+* `tags` - returns a Manager for interacting with the current project tags 
 
-Note that the `settings` Manager can also be used to update settings like so, assumibg you have a `snyk.models.Project` object in the variable `project`.
+You can add and delete tags using the manager:
+
+* `tags.add(key, value)` - adds a tag with the provided key/value pair to the project
+* `tags.delete(key, value)` - deletes a tag with the provided key/value pair from the project
+
+Note that the `settings` Manager can also be used to update settings like so, assuming you have a `snyk.models.Project` object in the variable `project`.
 
 ```python
 project.settings.update(pull_request_test_enabled=True)

--- a/snyk/managers.py
+++ b/snyk/managers.py
@@ -55,6 +55,7 @@ class Manager(abc.ABC):
                 "IssueSet": IssueSetManager,
                 "Integration": IntegrationManager,
                 "IntegrationSetting": IntegrationSettingManager,
+                "Tag": TagManager,
             }[key]
             return manager(klass, client, instance)
         except KeyError:
@@ -109,6 +110,27 @@ class OrganizationManager(Manager):
         return orgs
 
 
+class TagManager(Manager):
+    def all(self):
+        return self.instance._tags
+
+    def add(self, key, value) -> bool:
+        tag = {"key": key, "value": value}
+        path = "org/%s/project/%s/tags" % (
+            self.instance.organization.id,
+            self.instance.id,
+        )
+        return bool(self.client.post(path, tag))
+
+    def delete(self, key, value) -> bool:
+        tag = {"key": key, "value": value}
+        path = "org/%s/project/%s/tags/remove" % (
+            self.instance.organization.id,
+            self.instance.id,
+        )
+        return bool(self.client.post(path, tag))
+
+
 class ProjectManager(Manager):
     def all(self):
         projects = []
@@ -118,6 +140,13 @@ class ProjectManager(Manager):
             if "projects" in resp.json():
                 for project_data in resp.json()["projects"]:
                     project_data["organization"] = self.instance.to_dict()
+                    # We move tags to _tags as a cache, to avoid the need for additional requests
+                    # when working with tags. We want tags to be the manager
+                    try:
+                        project_data["_tags"] = project_data["tags"]
+                        del project_data["tags"]
+                    except KeyError:
+                        pass
                     projects.append(self.klass.from_dict(project_data))
             for x in projects:
                 x.organization = self.instance

--- a/snyk/models.py
+++ b/snyk/models.py
@@ -435,6 +435,7 @@ class Project(DataClassJSONMixin):
     hostname: Optional[str] = None
     remoteRepoUrl: Optional[str] = None
     branch: Optional[str] = None
+    _tags: Optional[List[Any]] = field(default_factory=list)
 
     def delete(self) -> bool:
         path = "org/%s/project/%s" % (self.organization.id, self.id)
@@ -471,6 +472,10 @@ class Project(DataClassJSONMixin):
     @property
     def vulnerabilities(self) -> List[Vulnerability]:
         return self.issueset.all().issues.vulnerabilities
+
+    @property
+    def tags(self) -> Manager:
+        return Manager.factory("Tag", self.organization.client, self)
 
     # https://snyk.docs.apiary.io/#reference/users/user-project-notification-settings/modify-project-notification-settings
     # https://snyk.docs.apiary.io/#reference/users/user-project-notification-settings/get-project-notification-settings

--- a/snyk/test_models.py
+++ b/snyk/test_models.py
@@ -237,6 +237,26 @@ class TestProject(TestModels):
         with pytest.raises(SnykError):
             project.delete()
 
+    def test_add_tag(self, project, project_url, requests_mock):
+        requests_mock.post(
+            "%s/tags" % project_url, json={"key": "key", "value": "value"}
+        )
+        assert project.tags.add("key", "value")
+
+    def test_delete_tag(self, project, project_url, requests_mock):
+        requests_mock.post(
+            "%s/tags/remove" % project_url, json={"key": "key", "value": "value"}
+        )
+        assert project.tags.delete("key", "value")
+
+    def test_tags(self, project, project_url, requests_mock):
+        assert [] == project.tags.all()
+
+    def test_tags_cache(self, project, project_url, requests_mock):
+        tags = [{"key": "key", "value": "value"}]
+        project._tags = tags
+        assert tags == project.tags.all()
+
     def test_empty_settings(self, project, project_url, requests_mock):
         requests_mock.get("%s/settings" % project_url, json={})
         assert {} == project.settings.all()


### PR DESCRIPTION
I standardized on delete as the verb here, to match the other API
methods. It's tags/delete on group and tags/remove on groups. It's
delete on projects.

I prefer the high-level consistency. We can add an alias if this ends up
confusing folks.