### PR TITLE
Added a workflow for releasing new versions for tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,29 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "*"
+
+jobs:
+  release:
+    name: Release to PyPi
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code 
+        uses: actions/checkout@v2
+
+      - name: Set up Python 3.7
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.7
+
+      - name: Install poetry
+        uses: dschep/install-poetry-action@v1.2
+
+      - name: Install Dependencies
+        run: poetry install -v
+
+      - name: Run pytest
+        shell: bash
+        run: poetry publish --build --username '__token__'  --password ${{ secrets.PYPI }}


### PR DESCRIPTION
This is untested, but looks like it _should_ work :)

I didn't use the caching as I reason always building clean for the release is a better option. Performance here is less of a concern.