### PR TITLE
Fix issue with project not having client after retrieving a project

### DIFF
--- a/snyk/managers.py
+++ b/snyk/managers.py
@@ -179,7 +179,9 @@ class ProjectManager(Manager):
             resp = self.client.get(path)
             project_data = resp.json()
             project_data["organization"] = self.instance.to_dict()
-            return self.klass.from_dict(project_data)
+            project_klass = self.klass.from_dict(project_data)
+            project_klass.organization = self.instance
+            return project_klass
         else:
             return super().get(id)
 

--- a/snyk/test_models.py
+++ b/snyk/test_models.py
@@ -266,6 +266,18 @@ class TestOrganization(TestModels):
             == organization.projects.get("6d5813be-7e6d-4ab8-80c2-1e3e2a454545").name
         )
 
+    def test_get_project_organization_has_client(
+        self, organization, project, requests_mock
+    ):
+        matcher = re.compile("project/6d5813be-7e6d-4ab8-80c2-1e3e2a454545$")
+        requests_mock.get(matcher, json=project)
+        assert (
+            organization.projects.get(
+                "6d5813be-7e6d-4ab8-80c2-1e3e2a454545"
+            ).organization.client
+            is not None
+        )
+
     def test_filter_projects_by_tag_missing_value(self, organization, requests_mock):
         with pytest.raises(SnykError):
             organization.projects.filter(tags=[{"key": "some-key"}])


### PR DESCRIPTION
This PR injects the client back to a project after a call to `Project.get()`
