### PR TITLE
Make license severity optional

### DIFF
--- a/snyk/models.py
+++ b/snyk/models.py
@@ -346,7 +346,7 @@ class License(DataClassJSONMixin):
     id: str
     dependencies: List[LicenseDependency]
     projects: List[LicenseProject]
-    severity: str
+    severity: Optional[str] = None
 
 
 @dataclass

--- a/snyk/test_models.py
+++ b/snyk/test_models.py
@@ -484,3 +484,33 @@ class TestProject(TestModels):
     def test_empty_licenses(self, project, organization_url, requests_mock):
         requests_mock.post("%s/licenses" % organization_url, json=[])
         assert [] == project.licenses.all()
+
+    def test_empty_license_severity(
+        self, organization, organization_url, requests_mock
+    ):
+        requests_mock.post(
+            "%s/licenses" % organization_url,
+            json={
+                "results": [
+                    {
+                        "id": "MIT",
+                        "dependencies": [
+                            {
+                                "id": "accepts@1.0.0",
+                                "name": "accepts",
+                                "version": "1.0.0",
+                                "packageManager": "npm",
+                            }
+                        ],
+                        "projects": [
+                            {
+                                "name": "atokeneduser/goof",
+                                "id": "6d5813be-7e6d-4ab8-80c2-1e3e2a454545",
+                            }
+                        ],
+                    }
+                ]
+            },
+        )
+        licenses = next(iter(organization.licenses.all()))
+        assert licenses.severity is None


### PR DESCRIPTION
According to the API schema, license severity should be optional