### PR TITLE
Make dependency graph package version optional

### DIFF
--- a/snyk/models.py
+++ b/snyk/models.py
@@ -376,7 +376,7 @@ class IssueCounts(DataClassJSONMixin):
 @dataclass
 class DependencyGraphPackageInfo(DataClassJSONMixin):
     name: str
-    version: str
+    version: Optional[str] = None
 
 
 @dataclass

--- a/snyk/test_models.py
+++ b/snyk/test_models.py
@@ -526,3 +526,24 @@ class TestProject(TestModels):
         )
         licenses = next(iter(organization.licenses.all()))
         assert licenses.severity is None
+
+    def test_missing_package_version_in_dep_graph(
+        self, project, project_url, requests_mock
+    ):
+        requests_mock.get(
+            "%s/dep-graph" % project_url,
+            json={
+                "depGraph": {
+                    "pkgManager": {"name": "fake-package-manager"},
+                    "pkgs": [
+                        {
+                            "id": "fake-package@x.y.z",
+                            "info": {"name": "fake-package-name"},
+                        }
+                    ],
+                    "schemaVersion": "fake",
+                    "graph": {"rootNodeId": "fake", "nodes": []},
+                }
+            },
+        )
+        assert next(iter(project.dependency_graph.pkgs)).info.version is None


### PR DESCRIPTION
Snyk API docs for fetching a project's dependency graph describe the package version as an optional attribute. This commit fixes that