### PR TITLE
Add `isPinnable` to Vulnerability class to match that output field in the API

### DIFF
--- a/examples/api-demo-5c-test-python-package.py
+++ b/examples/api-demo-5c-test-python-package.py
@@ -44,8 +44,7 @@ for v in all_vulnerability_issues:
     print("  severity: %s" % v.severity)
     print("  language: %s" % v.language)
     print("  packageManager: %s" % v.packageManager)
-    print("  isUpgradable: %s" % v.isUpgradable)
-    print("  isPatchable: %s" % v.isPatchable)
+    print("  isPinnable: %s" % v.isPinnable)
 
 print("\nLicense Issues:")
 for l in all_license_issues:

--- a/snyk/models.py
+++ b/snyk/models.py
@@ -22,6 +22,7 @@ class Vulnerability(DataClassJSONMixin):
     exploitMaturity: str
     isUpgradable: bool
     isPatchable: bool
+    isPinnable: bool
     identifiers: Any
     semver: Any
     fromPackages: List[str] = field(default_factory=list)


### PR DESCRIPTION
The API endpoints for testing a package produce results which include an `isPinnable` field in the issues/vulnerability (if it exists). This fix adds this `isPinnable` field to the `Vulnerability` class so that it can be had via this SDK.
