### PR TITLE
Fix: project vulnerabilities

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -110,6 +110,17 @@ optional = false
 python-versions = ">=3.5"
 
 [[package]]
+name = "deprecation"
+version = "2.1.0"
+description = "A library to handle automated deprecations"
+category = "main"
+optional = false
+python-versions = "*"
+
+[package.dependencies]
+packaging = "*"
+
+[[package]]
 name = "filelock"
 version = "3.5.1"
 description = "A platform independent file lock."
@@ -213,7 +224,7 @@ python-versions = "*"
 name = "packaging"
 version = "21.3"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -255,7 +266,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 name = "pyparsing"
 version = "3.0.7"
 description = "Python parsing module"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=3.6"
 
@@ -496,7 +507,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "28cfce276385eb55c3d21f22c639de90c6dafe727c94e5cbb3de6389765641db"
+content-hash = "af5fbbbd55df71d2f5ffb2a4ecef47a234275734e1a2e48099493ac4804c818f"
 
 [metadata.files]
 appdirs = [
@@ -577,6 +588,10 @@ coverage = [
 decorator = [
     {file = "decorator-5.1.1-py3-none-any.whl", hash = "sha256:b8c3f85900b9dc423225913c5aace94729fe1fa9763b38939a95226f02d37186"},
     {file = "decorator-5.1.1.tar.gz", hash = "sha256:637996211036b6385ef91435e4fae22989472f9d571faba8927ba8253acbc330"},
+]
+deprecation = [
+    {file = "deprecation-2.1.0-py2.py3-none-any.whl", hash = "sha256:a10811591210e1fb0e768a8c25517cabeabcba6f0bf96564f8ff45189f90b14a"},
+    {file = "deprecation-2.1.0.tar.gz", hash = "sha256:72b3bde64e5d778694b0cf68178aed03d15e15477116add3fb773e581f9518ff"},
 ]
 filelock = [
     {file = "filelock-3.5.1-py3-none-any.whl", hash = "sha256:7b23620a293cf3e19924e469cb96672dc72b36c26e8f80f85668310117fcbe4e"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysnyk"
-version = "0.7.0"
+version = "0.8.0"
 description = "A Python client for the Snyk API"
 authors = [
   "Gareth Rushgrove <garethr@snyk.io>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ requests = "^2.22"
 mashumaro = "^3"
 importlib_metadata = "^4.4"
 retry = "^0.9.2"
+deprecation = "^2.1.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.5"

--- a/snyk/managers.py
+++ b/snyk/managers.py
@@ -61,6 +61,7 @@ class Manager(abc.ABC):
                 "Integration": IntegrationManager,
                 "IntegrationSetting": IntegrationSettingManager,
                 "Tag": TagManager,
+                "IssuePaths": IssuePathsManager,
             }[key]
             return manager(klass, client, instance)
         except KeyError:
@@ -435,4 +436,15 @@ class IssueSetAggregatedManager(SingletonManager):
                 post_body[optional_field] = kwargs[optional_field]
 
         resp = self.client.post(path, post_body)
+        return self.klass.from_dict(resp.json())
+
+
+class IssuePathsManager(SingletonManager):
+    def all(self):
+        path = "org/%s/project/%s/issue/%s/paths" % (
+            self.instance.organization_id,
+            self.instance.project_id,
+            self.instance.id,
+        )
+        resp = self.client.get(path)
         return self.klass.from_dict(resp.json())

--- a/snyk/managers.py
+++ b/snyk/managers.py
@@ -1,6 +1,8 @@
 import abc
 from typing import Any, Dict, List
 
+from deprecation import deprecated  # type: ignore
+
 from .errors import SnykError, SnykNotFoundError, SnykNotImplementedError
 from .utils import snake_to_camel
 
@@ -366,6 +368,7 @@ class DependencyGraphManager(SingletonManager):
         raise SnykError
 
 
+@deprecated("API has been removed, use IssueSetAggregatedManager instead")
 class IssueSetManager(SingletonManager):
     def _convert_reserved_words(self, data):
         for key in ["vulnerabilities", "licenses"]:

--- a/snyk/models.py
+++ b/snyk/models.py
@@ -82,7 +82,7 @@ class IssueData(DataClassJSONMixin):
     exploitMaturity: str
     description: Optional[str] = None
     identifiers: Optional[Any] = None
-    credit: Optional[str] = None
+    credit: Optional[List[str]] = None
     semver: Optional[Any] = None
     publicationTime: Optional[str] = None
     disclosureTime: Optional[str] = None
@@ -91,6 +91,18 @@ class IssueData(DataClassJSONMixin):
     language: Optional[str] = None
     patches: Optional[Any] = None
     nearestFixedInVersion: Optional[str] = None
+    ignoreReasons: Optional[List[Any]] = None
+
+
+@dataclass
+class FixInfo(DataClassJSONMixin):
+    isUpgradable: bool
+    isPinnable: bool
+    isPatchable: bool
+    isFixable: bool
+    isPartiallyFixable: bool
+    nearestFixedInVersion: str
+    fixedIn: List[str]
 
 
 @dataclass
@@ -102,9 +114,9 @@ class AggregatedIssue(DataClassJSONMixin):
     issueData: IssueData
     isPatched: bool
     isIgnored: bool
+    fixInfo: FixInfo
     introducedThrough: Optional[List[Any]] = None
     ignoreReasons: Optional[List[Any]] = None
-    fixInfo: Optional[Any] = None
     # Not mentioned in schema but returned
     # https://snyk.docs.apiary.io/#reference/projects/aggregated-project-issues/list-all-aggregated-issues
     priorityScore: Optional[int] = None

--- a/snyk/models.py
+++ b/snyk/models.py
@@ -135,6 +135,27 @@ class OrganizationGroup(DataClassJSONMixin):
 
 
 @dataclass
+class Package(DataClassJSONMixin):
+    name: str
+    version: str
+    fixVersion: Optional[str] = None
+
+
+@dataclass
+class IssuePaths(DataClassJSONMixin):
+    snapshotId: str
+    paths: List[List[Package]]
+    total: int
+
+
+@dataclass
+class IssueRelations:
+    id: str
+    organization_id: str
+    project_id: str
+
+
+@dataclass
 class Organization(DataClassJSONMixin):
     name: str
     id: str

--- a/snyk/models.py
+++ b/snyk/models.py
@@ -3,6 +3,7 @@ from dataclasses import InitVar, dataclass, field
 from typing import Any, Dict, List, Optional, Union
 
 import requests
+from deprecation import deprecated  # type: ignore
 from mashumaro.mixins.json import DataClassJSONMixin  # type: ignore
 
 from .errors import SnykError, SnykNotImplementedError
@@ -584,7 +585,9 @@ class Project(DataClassJSONMixin):
     def dependency_graph(self) -> DependencyGraph:
         return Manager.factory(DependencyGraph, self.organization.client, self).all()
 
-    @property
+    # mypy doesn't support decorated properties
+    @property  # type: ignore
+    @deprecated("Use issueset_aggregated")
     def issueset(self) -> Manager:
         return Manager.factory(IssueSet, self.organization.client, self)
 

--- a/snyk/test_models.py
+++ b/snyk/test_models.py
@@ -489,13 +489,7 @@ class TestProject(TestModels):
 
     def test_empty_vulnerabilities(self, project, project_url, requests_mock):
         requests_mock.post(
-            "%s/issues" % project_url,
-            json={
-                "ok": True,
-                "packageManager": "fake",
-                "dependencyCount": 0,
-                "issues": {"vulnerabilities": [], "licenses": []},
-            },
+            "%s/aggregated-issues" % project_url, json={"issues": []},
         )
         assert [] == project.vulnerabilities
 

--- a/snyk/test_utils.py
+++ b/snyk/test_utils.py
@@ -1,4 +1,5 @@
-from snyk.utils import snake_to_camel
+from snyk.models import Package
+from snyk.utils import flat_map, format_package, snake_to_camel
 
 
 class TestUtils(object):
@@ -6,3 +7,16 @@ class TestUtils(object):
         snake = "testing_this_value"
         camel = "testingThisValue"
         assert camel == snake_to_camel(snake)
+
+    def test_flat_map_transforms_values_then_flattens_result(self):
+        def double(value):
+            return [value, value]
+
+        case = [1, 2, 3]
+        expected = [1, 1, 2, 2, 3, 3]
+        assert flat_map(double, case) == expected
+
+    def test_format_package_formats_packages_as_simple_string(self):
+        case = Package(name="foo", version="123")
+        expected = "foo@123"
+        assert format_package(case) == expected

--- a/snyk/utils.py
+++ b/snyk/utils.py
@@ -1,4 +1,5 @@
 import re
+from itertools import chain
 
 
 def snake_to_camel(word):
@@ -9,3 +10,12 @@ def snake_to_camel(word):
 
 def lower_case_first_letter(word):
     return word[:1].lower() + word[1:] if word else ""
+
+
+def flat_map(fn, *args):
+    mapped = map(fn, *args)
+    return list(chain(*mapped))
+
+
+def format_package(pkg):
+    return "{name}@{version}".format(name=pkg.name, version=pkg.version or "*")


### PR DESCRIPTION
The project vulnerabilities property was using a deprecated and removed endpoint. This patch updates it to use the aggregated issues endpoint while somewhat preserving the public api. However it incurs an additional api call per issue which can be slow on some projects to maintain the same data.