### PR TITLE
Rename v3 to rest

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,59 +211,61 @@ client.post("<path>", <data>)
 
 Most of the time you shouldn't need to use these. They are mainly useful if new methods are added to the API which are not yet supported in the client. This can also be useful if you want to pass very specific parameters, or to parse the raw JSON output from the API.
 
-## Experimental v3 low-level client
+## Experimental rest low-level client
 
-pysnyk >= 0.9.0 now includes support for basic v3 compatibility. To switch to use a v3 client, pass the v3 API url and version when initializing a client. Right now it supports the `GET` method. Refer to the [v3 API docs](https://apidocs.snyk.io/) for more information and examples.
+pysnyk >= 0.9.0 now includes support for basic rest (formerly referred to as v3) compatibility. To switch to use a rest client, pass the rest API url and version when initializing a client. Right now it supports the `GET` method. Refer to the [rest API docs](https://apidocs.snyk.io/) for more information and examples.
 
-Getting the v3 information of an organization:
+Getting the rest information of an organization:
 
 ```python
 # To get this value, get it from a Snyk organizations settings page
 snyk_org = "df734bed-d75c-4f11-bb47-1d119913bcc7"
 
-# to use the v3 endpoint you MUST include a version value and the url of the v3 api endpoint as shown below
-v3client = SnykClient(snyk_token, version="2022-02-16~experimental", url="https://api.snyk.io/v3")
+# to use the rest endpoint you MUST include a version value and the url of the v3 api endpoint as shown below
+rest_client = SnykClient(snyk_token, version="2022-02-16~experimental", url="https://api.snyk.io/rest")
 
-print(v3client.get(f"/orgs/{snyk_org}").json())
+print(rest_client.get(f"/orgs/{snyk_org}").json())
 
-# this supports overriding v3 versions for a specific GET requests:
-user = v3client.get(f"orgs/{snyk_org}/users/{snyk_user}", version="2022-02-01~experimental").json()
+# this supports overriding rest versions for a specific GET requests:
+user = rest_client.get(f"orgs/{snyk_org}/users/{snyk_user}", version="2022-02-01~experimental").json()
 
 # pass parameters such as how many results per page
 params = {"limit": 10}
 
-targets = v3client.get(f"orgs/{snyk_org}/targets", params=params)
+targets = rest_client.get(f"orgs/{snyk_org}/targets", params=params)
 ```
 
-V1 and v3 can work at the same time by instantiating two clients:
+V1 and rest can work at the same time by instantiating two clients:
 
 ```python
 snyk_org = "df734bed-d75c-4f11-bb47-1d119913bcc7"
 
 v1client = SnykClient(snyk_token)
 
-v3client = SnykClient(snyk_token, version="2022-02-16~experimental", url="https://api.snyk.io/v3")
+rest_client = SnykClient(snyk_token, version="2022-02-16~experimental", url="https://api.snyk.io/rest")
 
 v1_org = v1client.organizations.get(snyk_org)
 
-v3_org = v3client.get(f"/orgs/{snyk_org}").json()
+rest_org = rest_client.get(f"/orgs/{snyk_org}").json()
 ```
 
-The v3 API introduces consistent pagination across all endpoints. The v3 client includes a helper method `.get_v3_pages` which collects the paginated responses and returns a single list combining the contents of the "data" key from all pages. It takes the same values as the get method.
+The rest API introduces consistent pagination across all endpoints. The v3 client includes a helper method `.get_rest_pages` which collects the paginated responses and returns a single list combining the contents of the "data" key from all pages. It takes the same values as the get method.
 
 ```python
-v3client = SnykClient(snyk_token, version="2022-02-16~experimental", url="https://api.snyk.io/v3")
+rest_client = SnykClient(snyk_token, version="2022-02-16~experimental", url="https://api.snyk.io/rest")
 
 params = {"limit": 10}
 
-targets = v3client.get(f"orgs/{snyk_org}/targets", params=params).json()
+targets = rest_client.get(f"orgs/{snyk_org}/targets", params=params).json()
 
 print(len(targets["data"]))
 # returns 10 targets
 
-all_targets = v3client.get_v3_pages(f"orgs/{snyk_org}/targets", params=params)
+all_targets = rest_client.get_rest_pages(f"orgs/{snyk_org}/targets", params=params)
 
 print(len(all_targets))
-# returns 33 targets, note we don't have to add .json() to the call or access the "data" key, get_v3_pages does that for us
+# returns 33 targets, note we don't have to add .json() to the call or access the "data" key, get_rest_pages does that for us
 
 ```
+
+For backwards compatibility the get_rest_pages method has an alternative name of get_v3_pages to not break code already rewritten replatformed to the 0.9.0 pysnyk module.

--- a/poetry.lock
+++ b/poetry.lock
@@ -137,7 +137,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "importlib-metadata"
-version = "4.11.2"
+version = "4.11.3"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
@@ -191,7 +191,7 @@ yaml = ["pyyaml (>=3.13)"]
 
 [[package]]
 name = "mypy"
-version = "0.931"
+version = "0.940"
 description = "Optional static typing for Python"
 category = "dev"
 optional = false
@@ -206,6 +206,7 @@ typing-extensions = ">=3.10"
 [package.extras]
 dmypy = ["psutil (>=4.0)"]
 python2 = ["typed-ast (>=1.4.0,<2)"]
+reports = ["lxml"]
 
 [[package]]
 name = "mypy-extensions"
@@ -452,7 +453,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-requests"
-version = "2.27.11"
+version = "2.27.12"
 description = "Typing stubs for requests"
 category = "dev"
 optional = false
@@ -471,7 +472,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-setuptools"
-version = "57.4.9"
+version = "57.4.10"
 description = "Typing stubs for setuptools"
 category = "dev"
 optional = false
@@ -487,7 +488,7 @@ python-versions = "*"
 
 [[package]]
 name = "types-urllib3"
-version = "1.26.10"
+version = "1.26.11"
 description = "Typing stubs for urllib3"
 category = "dev"
 optional = false
@@ -649,8 +650,8 @@ idna = [
     {file = "idna-3.3.tar.gz", hash = "sha256:9d643ff0a55b762d5cdb124b8eaa99c66322e2157b69160bc32796e824360e6d"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-4.11.2-py3-none-any.whl", hash = "sha256:d16e8c1deb60de41b8e8ed21c1a7b947b0bc62fab7e1d470bcdf331cea2e6735"},
-    {file = "importlib_metadata-4.11.2.tar.gz", hash = "sha256:b36ffa925fe3139b2f6ff11d6925ffd4fa7bc47870165e3ac260ac7b4f91e6ac"},
+    {file = "importlib_metadata-4.11.3-py3-none-any.whl", hash = "sha256:1208431ca90a8cca1a6b8af391bb53c1a2db74e5d1cef6ddced95d4b2062edc6"},
+    {file = "importlib_metadata-4.11.3.tar.gz", hash = "sha256:ea4c597ebf37142f827b8f39299579e31685c31d3a438b59f469406afd0f2539"},
 ]
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
@@ -665,26 +666,29 @@ mashumaro = [
     {file = "mashumaro-3.0.tar.gz", hash = "sha256:0e5c06faf17c9b7731e138c280fec56d8ccf9ffaccb7b0e2d9d8a923c850ff66"},
 ]
 mypy = [
-    {file = "mypy-0.931-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:3c5b42d0815e15518b1f0990cff7a705805961613e701db60387e6fb663fe78a"},
-    {file = "mypy-0.931-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:c89702cac5b302f0c5d33b172d2b55b5df2bede3344a2fbed99ff96bddb2cf00"},
-    {file = "mypy-0.931-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:300717a07ad09525401a508ef5d105e6b56646f7942eb92715a1c8d610149714"},
-    {file = "mypy-0.931-cp310-cp310-win_amd64.whl", hash = "sha256:7b3f6f557ba4afc7f2ce6d3215d5db279bcf120b3cfd0add20a5d4f4abdae5bc"},
-    {file = "mypy-0.931-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:1bf752559797c897cdd2c65f7b60c2b6969ffe458417b8d947b8340cc9cec08d"},
-    {file = "mypy-0.931-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:4365c60266b95a3f216a3047f1d8e3f895da6c7402e9e1ddfab96393122cc58d"},
-    {file = "mypy-0.931-cp36-cp36m-win_amd64.whl", hash = "sha256:1b65714dc296a7991000b6ee59a35b3f550e0073411ac9d3202f6516621ba66c"},
-    {file = "mypy-0.931-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:e839191b8da5b4e5d805f940537efcaa13ea5dd98418f06dc585d2891d228cf0"},
-    {file = "mypy-0.931-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:50c7346a46dc76a4ed88f3277d4959de8a2bd0a0fa47fa87a4cde36fe247ac05"},
-    {file = "mypy-0.931-cp37-cp37m-win_amd64.whl", hash = "sha256:d8f1ff62f7a879c9fe5917b3f9eb93a79b78aad47b533911b853a757223f72e7"},
-    {file = "mypy-0.931-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:f9fe20d0872b26c4bba1c1be02c5340de1019530302cf2dcc85c7f9fc3252ae0"},
-    {file = "mypy-0.931-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:1b06268df7eb53a8feea99cbfff77a6e2b205e70bf31743e786678ef87ee8069"},
-    {file = "mypy-0.931-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8c11003aaeaf7cc2d0f1bc101c1cc9454ec4cc9cb825aef3cafff8a5fdf4c799"},
-    {file = "mypy-0.931-cp38-cp38-win_amd64.whl", hash = "sha256:d9d2b84b2007cea426e327d2483238f040c49405a6bf4074f605f0156c91a47a"},
-    {file = "mypy-0.931-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:ff3bf387c14c805ab1388185dd22d6b210824e164d4bb324b195ff34e322d166"},
-    {file = "mypy-0.931-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5b56154f8c09427bae082b32275a21f500b24d93c88d69a5e82f3978018a0266"},
-    {file = "mypy-0.931-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:8ca7f8c4b1584d63c9a0f827c37ba7a47226c19a23a753d52e5b5eddb201afcd"},
-    {file = "mypy-0.931-cp39-cp39-win_amd64.whl", hash = "sha256:74f7eccbfd436abe9c352ad9fb65872cc0f1f0a868e9d9c44db0893440f0c697"},
-    {file = "mypy-0.931-py3-none-any.whl", hash = "sha256:1171f2e0859cfff2d366da2c7092b06130f232c636a3f7301e3feb8b41f6377d"},
-    {file = "mypy-0.931.tar.gz", hash = "sha256:0038b21890867793581e4cb0d810829f5fd4441aa75796b53033af3aa30430ce"},
+    {file = "mypy-0.940-cp310-cp310-macosx_10_9_universal2.whl", hash = "sha256:0fdc9191a49c77ab5fa0439915d405e80a1118b163ab03cd2a530f346b12566a"},
+    {file = "mypy-0.940-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:1903c92ff8642d521b4627e51a67e49f5be5aedb1fb03465b3aae4c3338ec491"},
+    {file = "mypy-0.940-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:471af97c35a32061883b0f8a3305ac17947fd42ce962ca9e2b0639eb9141492f"},
+    {file = "mypy-0.940-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:13677cb8b050f03b5bb2e8bf7b2668cd918b001d56c2435082bbfc9d5f730f42"},
+    {file = "mypy-0.940-cp310-cp310-win_amd64.whl", hash = "sha256:2efd76893fb8327eca7e942e21b373e6f3c5c083ff860fb1e82ddd0462d662bd"},
+    {file = "mypy-0.940-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f8fe1bfab792e4300f80013edaf9949b34e4c056a7b2531b5ef3a0fb9d598ae2"},
+    {file = "mypy-0.940-cp36-cp36m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:2dba92f58610d116f68ec1221fb2de2a346d081d17b24a784624389b17a4b3f9"},
+    {file = "mypy-0.940-cp36-cp36m-win_amd64.whl", hash = "sha256:712affcc456de637e774448c73e21c84dfa5a70bcda34e9b0be4fb898a9e8e07"},
+    {file = "mypy-0.940-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:8aaf18d0f8bc3ffba56d32a85971dfbd371a5be5036da41ac16aefec440eff17"},
+    {file = "mypy-0.940-cp37-cp37m-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:51be997c1922e2b7be514a5215d1e1799a40832c0a0dee325ba8794f2c48818f"},
+    {file = "mypy-0.940-cp37-cp37m-win_amd64.whl", hash = "sha256:628f5513268ebbc563750af672ccba5eef7f92d2d90154233edd498dfb98ca4e"},
+    {file = "mypy-0.940-cp38-cp38-macosx_10_9_universal2.whl", hash = "sha256:68038d514ae59d5b2f326be502a359160158d886bd153fc2489dbf7a03c44c96"},
+    {file = "mypy-0.940-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:b2fa5f2d597478ccfe1f274f8da2f50ea1e63da5a7ae2342c5b3b2f3e57ec340"},
+    {file = "mypy-0.940-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:b1a116c451b41e35afc09618f454b5c2704ba7a4e36f9ff65014fef26bb6075b"},
+    {file = "mypy-0.940-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:1f66f2309cdbb07e95e60e83fb4a8272095bd4ea6ee58bf9a70d5fb304ec3e3f"},
+    {file = "mypy-0.940-cp38-cp38-win_amd64.whl", hash = "sha256:3ac14949677ae9cb1adc498c423b194ad4d25b13322f6fe889fb72b664c79121"},
+    {file = "mypy-0.940-cp39-cp39-macosx_10_9_universal2.whl", hash = "sha256:6eab2bcc2b9489b7df87d7c20743b66d13254ad4d6430e1dfe1a655d51f0933d"},
+    {file = "mypy-0.940-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:0b52778a018559a256c819ee31b2e21e10b31ddca8705624317253d6d08dbc35"},
+    {file = "mypy-0.940-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:d9d7647505bf427bc7931e8baf6cacf9be97e78a397724511f20ddec2a850752"},
+    {file = "mypy-0.940-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a0e5657ccaedeb5fdfda59918cc98fc6d8a8e83041bc0cec347a2ab6915f9998"},
+    {file = "mypy-0.940-cp39-cp39-win_amd64.whl", hash = "sha256:83f66190e3c32603217105913fbfe0a3ef154ab6bbc7ef2c989f5b2957b55840"},
+    {file = "mypy-0.940-py3-none-any.whl", hash = "sha256:a168da06eccf51875fdff5f305a47f021f23f300e2b89768abdac24538b1f8ec"},
+    {file = "mypy-0.940.tar.gz", hash = "sha256:71bec3d2782d0b1fecef7b1c436253544d81c1c0e9ca58190aed9befd8f081c5"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -788,24 +792,24 @@ types-backports = [
     {file = "types_backports-0.1.3-py2.py3-none-any.whl", hash = "sha256:dafcd61848081503e738a7768872d1dd6c018401b4d2a1cfb608ea87ec9864b9"},
 ]
 types-requests = [
-    {file = "types-requests-2.27.11.tar.gz", hash = "sha256:6a7ed24b21780af4a5b5e24c310b2cd885fb612df5fd95584d03d87e5f2a195a"},
-    {file = "types_requests-2.27.11-py3-none-any.whl", hash = "sha256:506279bad570c7b4b19ac1f22e50146538befbe0c133b2cea66a9b04a533a859"},
+    {file = "types-requests-2.27.12.tar.gz", hash = "sha256:fd1382fa2e28eac848faedb0332840204f06f0cb517008e3c7b8282ca53e56d2"},
+    {file = "types_requests-2.27.12-py3-none-any.whl", hash = "sha256:120c949953b618e334bbe78de38e65aa261e1f48df021a05f0be833a848e4ba7"},
 ]
 types-retry = [
     {file = "types-retry-0.9.5.tar.gz", hash = "sha256:35a2ff8b987258154fb9c302a39df9e8691041b785f34a444a8d47660ef9b4cd"},
     {file = "types_retry-0.9.5-py3-none-any.whl", hash = "sha256:591393de4b821e6609914c62e64e4334c1ad7707d84ec9ee47ceae901ce6c23f"},
 ]
 types-setuptools = [
-    {file = "types-setuptools-57.4.9.tar.gz", hash = "sha256:536ef74744f8e1e4be4fc719887f886e74e4cf3c792b4a06984320be4df450b5"},
-    {file = "types_setuptools-57.4.9-py3-none-any.whl", hash = "sha256:948dc6863373750e2cd0b223a84f1fb608414cde5e55cf38ea657b93aeb411d2"},
+    {file = "types-setuptools-57.4.10.tar.gz", hash = "sha256:9a13513679c640f6616e2d9ab50d431c99ca8ae9848a97243f887c80fd5cf294"},
+    {file = "types_setuptools-57.4.10-py3-none-any.whl", hash = "sha256:ddc98da82c12e1208012d65276641a132d3aadc78ecfff68fd3e17d85933a3c1"},
 ]
 types-toml = [
     {file = "types-toml-0.10.4.tar.gz", hash = "sha256:9340e7c1587715581bb13905b3af30b79fe68afaccfca377665d5e63b694129a"},
     {file = "types_toml-0.10.4-py3-none-any.whl", hash = "sha256:4a9ffd47bbcec49c6fde6351a889b2c1bd3c0ef309fa0eed60dc28e58c8b9ea6"},
 ]
 types-urllib3 = [
-    {file = "types-urllib3-1.26.10.tar.gz", hash = "sha256:a26898f530e6c3f43f25b907f2b884486868ffd56a9faa94cbf9b3eb6e165d6a"},
-    {file = "types_urllib3-1.26.10-py3-none-any.whl", hash = "sha256:d755278d5ecd7a7a6479a190e54230f241f1a99c19b81518b756b19dc69e518c"},
+    {file = "types-urllib3-1.26.11.tar.gz", hash = "sha256:24d64e441168851eb05f1d022de18ae31558f5649c8f1117e384c2e85e31315b"},
+    {file = "types_urllib3-1.26.11-py3-none-any.whl", hash = "sha256:bd0abc01e9fb963e4fddd561a56d21cc371b988d1245662195c90379077139cd"},
 ]
 typing-extensions = [
     {file = "typing_extensions-4.1.1-py3-none-any.whl", hash = "sha256:21c85e0fe4b9a155d0799430b0ad741cdce7e359660ccbd8b530613e8df88ce2"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysnyk"
-version = "0.9.0"
+version = "0.9.1"
 description = "A Python client for the Snyk API"
 authors = [
   "Gareth Rushgrove <garethr@snyk.io>",

--- a/snyk/client.py
+++ b/snyk/client.py
@@ -107,8 +107,8 @@ class SnykClient(object):
         self, path: str, params: dict = None, version: str = None
     ) -> requests.Response:
         """
-        V3 Compatible Snyk Client, assumes the presence of Version, either set in the client
-        or called in this method means that we're talking to a V3 endpoint and will ensure the
+        Rest (formerly v3) Compatible Snyk Client, assumes the presence of Version, either set in the client
+        or called in this method means that we're talking to a rest API endpoint and will ensure the
         params are encoded properly with the version.
 
         Since certain endpoints can exist only in certain versions, being able to override the
@@ -126,12 +126,12 @@ class SnykClient(object):
             if not params:
                 params = {}
 
-            # we use the presence of version to determine if we are v3 or not
+            # we use the presence of version to determine if we are REST or not
             if "version" not in params.keys() and self.version:
                 params["version"] = version or self.version
 
             # Python Bools are True/False, JS Bools are true/false
-            # Snyk v3 API is strictly case sensitive at the moment
+            # Snyk REST API is strictly case sensitive at the moment
 
             for k, v in params.items():
                 if isinstance(v, bool):
@@ -175,9 +175,9 @@ class SnykClient(object):
             raise SnykHTTPError(resp)
         return resp
 
-    def get_v3_pages(self, path: str, params: dict = {}) -> List:
+    def get_rest_pages(self, path: str, params: dict = {}) -> List:
         """
-        Helper function to collect paginated responses from the V3 API into a single
+        Helper function to collect paginated responses from the rest API into a single
         list.
 
         This collects the "data" list from the first reponse and then appends the
@@ -196,7 +196,9 @@ class SnykClient(object):
         data.extend(page["data"])
 
         while "next" in page["links"].keys():
-            logger.debug(f"GET_V3_PAGES: Another link exists: {page['links']['next']}")
+            logger.debug(
+                f"GET_REST_PAGES: Another link exists: {page['links']['next']}"
+            )
 
             next_url = urllib.parse.urlsplit(page["links"]["next"])
             query = urllib.parse.parse_qs(next_url.query)
@@ -211,10 +213,13 @@ class SnykClient(object):
             data.extend(page["data"])
 
             logger.debug(
-                f"GET_V3_PAGES: Added another {len(page['data'])} items to the response"
+                f"GET_REST_PAGES: Added another {len(page['data'])} items to the response"
             )
 
         return data
+
+    # alias for backwards compatibility where V3 was the old name
+    get_v3_pages = get_rest_pages
 
     @property
     def organizations(self) -> Manager:

--- a/snyk/test_client.py
+++ b/snyk/test_client.py
@@ -11,6 +11,10 @@ from snyk.utils import load_test_data
 
 TEST_DATA = os.path.join(os.path.dirname(__file__), "test_data")
 
+REST_ORG = "39ddc762-b1b9-41ce-ab42-defbe4575bd6"
+REST_URL = "https://api.snyk.io/rest"
+REST_VERSION = "2022-02-16~experimental"
+
 V3_ORG = "39ddc762-b1b9-41ce-ab42-defbe4575bd6"
 V3_URL = "https://api.snyk.io/v3"
 V3_VERSION = "2022-02-16~experimental"
@@ -202,7 +206,13 @@ class TestSnykClient(object):
             client.projects.get("not-present")
 
     @pytest.fixture
-    def v3client(self):
+    def rest_client(self):
+        return SnykClient(
+            "token", version="2022-02-16~experimental", url="https://api.snyk.io/rest"
+        )
+
+    @pytest.fixture
+    def v3_client(self):
         return SnykClient(
             "token", version="2022-02-16~experimental", url="https://api.snyk.io/v3"
         )
@@ -223,21 +233,37 @@ class TestSnykClient(object):
     def v3_targets_page3(self):
         return load_test_data(TEST_DATA, "v3_targets_page3")
 
-    def test_v3get(self, requests_mock, v3client, v3_targets_page1):
+    @pytest.fixture
+    def rest_groups(self):
+        return load_test_data(TEST_DATA, "rest_groups")
+
+    @pytest.fixture
+    def rest_targets_page1(self):
+        return load_test_data(TEST_DATA, "rest_targets_page1")
+
+    @pytest.fixture
+    def rest_targets_page2(self):
+        return load_test_data(TEST_DATA, "rest_targets_page2")
+
+    @pytest.fixture
+    def rest_targets_page3(self):
+        return load_test_data(TEST_DATA, "rest_targets_page3")
+
+    def test_v3get(self, requests_mock, v3_client, v3_targets_page1):
         requests_mock.get(
             f"{V3_URL}/orgs/{V3_ORG}/targets?limit=10&version={V3_VERSION}",
             json=v3_targets_page1,
         )
         t_params = {"limit": 10}
 
-        targets = v3client.get(f"orgs/{V3_ORG}/targets", t_params).json()
+        targets = v3_client.get(f"orgs/{V3_ORG}/targets", t_params).json()
 
         assert len(targets["data"]) == 10
 
     def test_get_v3_pages(
         self,
         requests_mock,
-        v3client,
+        v3_client,
         v3_targets_page1,
         v3_targets_page2,
         v3_targets_page3,
@@ -256,6 +282,43 @@ class TestSnykClient(object):
         )
         t_params = {"limit": 10}
 
-        data = v3client.get_v3_pages(f"orgs/{V3_ORG}/targets", t_params)
+        data = v3_client.get_v3_pages(f"orgs/{V3_ORG}/targets", t_params)
+
+        assert len(data) == 30
+
+    def test_rest_get(self, requests_mock, rest_client, rest_targets_page1):
+        requests_mock.get(
+            f"{REST_URL}/orgs/{REST_ORG}/targets?limit=10&version={REST_VERSION}",
+            json=rest_targets_page1,
+        )
+        t_params = {"limit": 10}
+
+        targets = rest_client.get(f"orgs/{REST_ORG}/targets", t_params).json()
+
+        assert len(targets["data"]) == 10
+
+    def test_get_rest_pages(
+        self,
+        requests_mock,
+        rest_client,
+        rest_targets_page1,
+        rest_targets_page2,
+        rest_targets_page3,
+    ):
+        requests_mock.get(
+            f"{REST_URL}/orgs/{REST_ORG}/targets?limit=10&version={REST_VERSION}",
+            json=rest_targets_page1,
+        )
+        requests_mock.get(
+            f"{REST_URL}/orgs/{REST_ORG}/targets?limit=10&version={REST_VERSION}&excludeEmpty=true&starting_after=v1.eyJpZCI6IjMyODE4ODAifQ%3D%3D",
+            json=rest_targets_page2,
+        )
+        requests_mock.get(
+            f"{REST_URL}/orgs/{REST_ORG}/targets?limit=10&version={REST_VERSION}&excludeEmpty=true&starting_after=v1.eyJpZCI6IjI5MTk1NjgifQ%3D%3D",
+            json=rest_targets_page3,
+        )
+        t_params = {"limit": 10}
+
+        data = rest_client.get_rest_pages(f"orgs/{V3_ORG}/targets", t_params)
 
         assert len(data) == 30

--- a/snyk/test_data/rest_groups.json
+++ b/snyk/test_data/rest_groups.json
@@ -1,0 +1,22 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "data": [
+    {
+      "type": "group",
+      "id": "36863d40-ba29-491f-af63-7a1a7d79e411",
+      "attributes": {
+        "name": "Customer Success Engineering"
+      }
+    },
+    {
+      "type": "group",
+      "id": "164f8e6d-ea58-45ef-a638-259cc0fe90d4",
+      "attributes": {
+        "name": "Goof Ltd (Enterprise)"
+      }
+    }
+  ],
+  "links": {}
+}

--- a/snyk/test_data/rest_targets_page1.json
+++ b/snyk/test_data/rest_targets_page1.json
@@ -1,0 +1,120 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "data": [
+    {
+      "type": "target",
+      "id": "44948be7-561c-4e03-80af-27232eaea006",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "cli",
+        "displayName": "snyk-playground/maven-multi-with-gh-prevent",
+        "remoteUrl": "http://github.com/snyk-playground/maven-multi-with-gh-prevent.git"
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "c3035b3b-9416-4d00-9e49-bdb561560ea8",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/maven-multi-with-gh-prevent",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "b17a13c7-25f4-4360-bba5-d1098efb579c",
+      "attributes": {
+        "isPrivate": false,
+        "origin": "github-enterprise",
+        "displayName": "snyk-tech-services/snyk-project-tldr",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "d3ce9715-6cd8-4940-b326-5fa7d35988f2",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "cli",
+        "displayName": "snyk-tech-services/snyk-bulk-yarn",
+        "remoteUrl": "http://github.com/snyk-tech-services/snyk-bulk-yarn"
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "3d8fd759-1fdf-4827-91a7-8706d54462de",
+      "attributes": {
+        "isPrivate": false,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/sync-aws-deploy",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "f26b4ae2-59e5-4be9-978d-0b2157d04d7c",
+      "attributes": {
+        "isPrivate": false,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/bazel-examples",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "1aae46bd-13e1-4c6c-9cbe-8849732ec00e",
+      "attributes": {
+        "isPrivate": false,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/example-bazel-monorepo",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "f6017bfd-e441-4482-b060-78e56daff65c",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/docker-goof",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "84519645-6a5a-4b0f-9132-a65e76d3aa03",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/monorepo-kotlin",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "dc2aa733-550d-43dd-9066-e9a35b6f3982",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/org-import-branch-override",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    }
+  ],
+  "links": {
+    "next": "/orgs/39ddc762-b1b9-41ce-ab42-defbe4575bd6/targets?limit=10&version=2022-02-16~experimental&excludeEmpty=true&starting_after=v1.eyJpZCI6IjMyODE4ODAifQ%3D%3D"
+  }
+}

--- a/snyk/test_data/rest_targets_page2.json
+++ b/snyk/test_data/rest_targets_page2.json
@@ -1,0 +1,121 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "data": [
+    {
+      "type": "target",
+      "id": "9a181724-d17d-4a92-a85c-72594c0df5e1",
+      "attributes": {
+        "isPrivate": false,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/org-import-instance",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "9aafc91d-76c1-4279-aa27-6e648130f003",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/pygithub-import-parser",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "bcb30f5f-ae18-4d32-ac62-1459b10050ae",
+      "attributes": {
+        "isPrivate": false,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/org-project-import",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "08beb7e6-ccdf-437a-95dd-9f3c8ad66cd8",
+      "attributes": {
+        "isPrivate": false,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/repo-with-jira-config",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "e29608d3-75dc-46ad-8ef4-3bf3c0331f35",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "github",
+        "displayName": "snyk-playground/multi-project-code",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "f94abd6f-d436-4aa8-b4d0-51523a7224c5",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "github",
+        "displayName": "scotte-snyk/example-yarn",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "b248a8b5-98a6-4a08-831c-748776ebc1d9",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "github",
+        "displayName": "scotte-snyk/test-ruby-project",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "53c9a6b1-a46c-44a3-a11f-296b9bd88e1e",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "github",
+        "displayName": "scotte-snyk/demo-sonarr-renamed",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "0e8f2413-af32-45a2-92f5-b9f8ada48374",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "github",
+        "displayName": "scotte-snyk/vulnerable-php-app",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "e52ec5a2-6b11-457e-a8fc-4d86e6fbfab1",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "cli",
+        "displayName": "kozmer/log4j-shell-poc",
+        "remoteUrl": "http://github.com/kozmer/log4j-shell-poc.git"
+      },
+      "relationships": {}
+    }
+  ],
+  "links": {
+    "next": "/orgs/39ddc762-b1b9-41ce-ab42-defbe4575bd6/targets?limit=10&version=2022-02-16~experimental&excludeEmpty=true&starting_after=v1.eyJpZCI6IjI5MTk1NjgifQ%3D%3D",
+    "prev": "/orgs/39ddc762-b1b9-41ce-ab42-defbe4575bd6/targets?limit=10&version=2022-02-16~experimental&excludeEmpty=true&ending_before=v1.eyJpZCI6IjMyODE4NzkifQ%3D%3D"
+  }
+}

--- a/snyk/test_data/rest_targets_page3.json
+++ b/snyk/test_data/rest_targets_page3.json
@@ -1,0 +1,120 @@
+{
+  "jsonapi": {
+    "version": "1.0"
+  },
+  "data": [
+    {
+      "type": "target",
+      "id": "44948be7-561c-4e03-80af-27232eaea006",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "cli",
+        "displayName": "snyk-playground/maven-multi-with-gh-prevent",
+        "remoteUrl": "http://github.com/snyk-playground/maven-multi-with-gh-prevent.git"
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "c3035b3b-9416-4d00-9e49-bdb561560ea8",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/maven-multi-with-gh-prevent",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "b17a13c7-25f4-4360-bba5-d1098efb579c",
+      "attributes": {
+        "isPrivate": false,
+        "origin": "github-enterprise",
+        "displayName": "snyk-tech-services/snyk-project-tldr",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "d3ce9715-6cd8-4940-b326-5fa7d35988f2",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "cli",
+        "displayName": "snyk-tech-services/snyk-bulk-yarn",
+        "remoteUrl": "http://github.com/snyk-tech-services/snyk-bulk-yarn"
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "3d8fd759-1fdf-4827-91a7-8706d54462de",
+      "attributes": {
+        "isPrivate": false,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/sync-aws-deploy",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "f26b4ae2-59e5-4be9-978d-0b2157d04d7c",
+      "attributes": {
+        "isPrivate": false,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/bazel-examples",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "1aae46bd-13e1-4c6c-9cbe-8849732ec00e",
+      "attributes": {
+        "isPrivate": false,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/example-bazel-monorepo",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "f6017bfd-e441-4482-b060-78e56daff65c",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/docker-goof",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "84519645-6a5a-4b0f-9132-a65e76d3aa03",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/monorepo-kotlin",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    },
+    {
+      "type": "target",
+      "id": "dc2aa733-550d-43dd-9066-e9a35b6f3982",
+      "attributes": {
+        "isPrivate": true,
+        "origin": "github-enterprise",
+        "displayName": "snyk-playground/org-import-branch-override",
+        "remoteUrl": null
+      },
+      "relationships": {}
+    }
+  ],
+  "links": {
+    "prev": "/orgs/39ddc762-b1b9-41ce-ab42-defbe4575bd6/targets?limit=10&version=2022-02-16~experimental&excludeEmpty=true&ending_before=v1.eyJpZCI6IjMyODE4ODAifQ%3D%3D"
+  }
+}


### PR DESCRIPTION
The original v3 endpoint has been renamed to rest and the previous url
has been deprecated. This renames the functions and references to v3 to
rest but also keeps in place the set of v3 test data and an alternative
name for the get_rest_pages functions as get_v3_pages for existing users