### PR TITLE
Removes the warning for excessive "/"

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysnyk"
-version = "0.9.1"
+version = "0.9.2"
 description = "A Python client for the Snyk API"
 authors = [
   "Gareth Rushgrove <garethr@snyk.io>",

--- a/snyk/client.py
+++ b/snyk/client.py
@@ -117,7 +117,7 @@ class SnykClient(object):
         Returns a standard requests Response object
         """
 
-        path = cleanup_path(path, logger)
+        path = cleanup_path(path)
 
         url = f"{self.api_url}/{path}"
 

--- a/snyk/utils.py
+++ b/snyk/utils.py
@@ -22,17 +22,15 @@ def format_package(pkg):
     return "{name}@{version}".format(name=pkg.name, version=pkg.version or "*")
 
 
-def cleanup_path(path: str, logger: logging.Logger) -> str:
+def cleanup_path(path: str) -> str:
     """
     Strings '/' from the start and end of strings if present to ensure that a '//' doesn't
     occur in an API request due to copy/paste error
     """
 
     if path[0] == "/":
-        logger.warn(f"removing unneccessary leading / from {path}")
         path = path[1:]
     if path[-1] == "/":
-        logger.warn(f"removing unneccessary trailing / from {path}")
         path = path.rstrip("/")
 
     return path


### PR DESCRIPTION
Our next/last pagination data includes fields such as "/orgs" so we make
ecessive warnings when really the primary user of this cleanup function
is our own code, in the get_rest_pages function.