### PR TITLE
Add support for cloning integrations between orgs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysnyk"
-version = "0.9.3"
+version = "0.9.4"
 description = "A Python client for the Snyk API"
 authors = [
   "Gareth Rushgrove <garethr@snyk.io>",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysnyk"
-version = "0.9.2"
+version = "0.9.3"
 description = "A Python client for the Snyk API"
 authors = [
   "Gareth Rushgrove <garethr@snyk.io>",

--- a/snyk/models.py
+++ b/snyk/models.py
@@ -359,6 +359,21 @@ class Integration(DataClassJSONMixin):
     id: str
     organization: Optional[Organization] = None
 
+    def clone(self, target_organization_id) -> bool:
+        if not self.organization:
+            raise SnykError
+
+        path = "org/%s/integrations/%s/clone" % (self.organization.id, self.id)
+
+        if self.organization.client is None:
+            raise SnykError
+
+        return bool(
+            self.organization.client.post(
+                path, {"destinationOrgPublicId": target_organization_id}
+            )
+        )
+
     @property
     def settings(self):
         if not self.organization:

--- a/snyk/test_models.py
+++ b/snyk/test_models.py
@@ -212,6 +212,15 @@ class TestOrganization(TestModels):
         with pytest.raises(SnykError):
             organization.test_rubygem("puppet", "4.0.0")
 
+    def test_clone_integration(self, organization, organization_url, requests_mock):
+        output = {"github": "not-a-real-id"}
+        requests_mock.get("%s/integrations" % organization_url, json=output)
+        requests_mock.post("%s/integrations/not-a-real-id/clone" % organization_url)
+        gh = organization.integrations.first()
+        assert gh.clone("target-org-id")
+        payload = requests_mock.last_request.json()
+        assert payload["destinationOrgPublicId"] == "target-org-id"
+
     def test_import_git(self, organization, requests_mock):
         integration_matcher = re.compile("integrations$")
         import_matcher = re.compile("import$")


### PR DESCRIPTION
Added method to allow [cloning integrations](https://snyk.docs.apiary.io/#reference/integrations/integration-cloning/clone-an-integration-(with-settings-and-credentials)) from one organization to another.