### PR TITLE
Improve logging of errors returned by API and allow setting headers when interacting with v3 API

### DIFF
--- a/README.md
+++ b/README.md
@@ -266,6 +266,8 @@ all_targets = rest_client.get_rest_pages(f"orgs/{snyk_org}/targets", params=para
 print(len(all_targets))
 # returns 33 targets, note we don't have to add .json() to the call or access the "data" key, get_rest_pages does that for us
 
+# Override Content-Type header (or others) as needed for 
+response = rest_client.post(f"orgs/{snyk_org}/invites", body={"email": "some.body@snyk.io", "role": "f8223479-01a9-4774-8e29-06ce9a0513d6", headers={"Content-Type": "application/vnd.api+json"}})
 ```
 
 For backwards compatibility the get_rest_pages method has an alternative name of get_v3_pages to not break code already rewritten replatformed to the 0.9.0 pysnyk module.

--- a/snyk/client.py
+++ b/snyk/client.py
@@ -68,39 +68,48 @@ class SnykClient(object):
             resp = method(url, headers=headers)
 
         if not resp or resp.status_code >= requests.codes.server_error:
+            logger.warning(f"Retrying: {resp.text}")
             raise SnykHTTPError(resp)
         return resp
 
-    def post(self, path: str, body: Any) -> requests.Response:
+    def post(self, path: str, body: Any, headers: dict = {}) -> requests.Response:
         url = f"{self.api_url}/{path}"
         logger.debug(f"POST: {url}")
+
         resp = retry_call(
             self.request,
             fargs=[requests.post, url],
-            fkwargs={"json": body, "headers": self.api_post_headers},
+            fkwargs={"json": body, "headers": {**self.api_post_headers, **headers}},
             tries=self.tries,
             delay=self.delay,
             backoff=self.backoff,
+            exceptions=SnykHTTPError,
             logger=logger,
         )
-        if not resp:
+
+        if not resp.ok:
+            logger.error(resp.text)
             raise SnykHTTPError(resp)
+
         return resp
 
-    def put(self, path: str, body: Any) -> requests.Response:
+    def put(self, path: str, body: Any, headers: dict = {}) -> requests.Response:
         url = "%s/%s" % (self.api_url, path)
         logger.debug("PUT: %s" % url)
+
         resp = retry_call(
             self.request,
             fargs=[requests.put, url],
-            fkwargs={"json": body, "headers": self.api_post_headers},
+            fkwargs={"json": body, "headers": {**self.api_post_headers, **headers}},
             tries=self.tries,
             delay=self.delay,
             backoff=self.backoff,
             logger=logger,
         )
-        if not resp:
+        if not resp.ok:
+            logger.error(resp.text)
             raise SnykHTTPError(resp)
+
         return resp
 
     def get(
@@ -154,14 +163,16 @@ class SnykClient(object):
             backoff=self.backoff,
             logger=logger,
         )
-
-        if not resp:
+        if not resp.ok:
+            logger.error(resp.text)
             raise SnykHTTPError(resp)
+
         return resp
 
     def delete(self, path: str) -> requests.Response:
         url = f"{self.api_url}/{path}"
         logger.debug(f"DELETE: {url}")
+
         resp = retry_call(
             self.request,
             fargs=[requests.delete, url],
@@ -171,8 +182,10 @@ class SnykClient(object):
             backoff=self.backoff,
             logger=logger,
         )
-        if not resp:
+        if not resp.ok:
+            logger.error(resp.text)
             raise SnykHTTPError(resp)
+
         return resp
 
     def get_rest_pages(self, path: str, params: dict = {}) -> List:

--- a/snyk/errors.py
+++ b/snyk/errors.py
@@ -14,7 +14,7 @@ class SnykHTTPError(SnykError):
                 data = resp.json()
                 self.code = data.get("code")
                 self.message = data.get("message")
-                self.error = data.get("error")
+                self.error = data.get("error") or data.get("errors")
             except json.decoder.JSONDecodeError:
                 self.code = resp.status_code
 


### PR DESCRIPTION
Closes #152 and closes #153.

In testing the beta feature to support custom roles we want to update our code to use the API to set this role upon invitation.  These changes are were required to support our workflow.