### PR TITLE
fix: use TagManager when getting a project by id

### DIFF
--- a/snyk/managers.py
+++ b/snyk/managers.py
@@ -183,6 +183,13 @@ class ProjectManager(Manager):
             resp = self.client.get(path)
             project_data = resp.json()
             project_data["organization"] = self.instance.to_dict()
+            # We move tags to _tags as a cache, to avoid the need for additional requests
+            # when working with tags. We want tags to be the manager
+            try:
+                project_data["_tags"] = project_data["tags"]
+                del project_data["tags"]
+            except KeyError:
+                pass
             project_klass = self.klass.from_dict(project_data)
             project_klass.organization = self.instance
             return project_klass

--- a/snyk/test_models.py
+++ b/snyk/test_models.py
@@ -319,6 +319,15 @@ class TestOrganization(TestModels):
         projects = organization.projects.all()
         assert projects[0]._tags == [{"key": "some-key", "value": "some-value"}]
 
+    def test_get_organization_project_has_tags(
+        self, organization, project, requests_mock
+    ):
+        matcher = re.compile("project/6d5813be-7e6d-4ab8-80c2-1e3e2a454545$")
+        requests_mock.get(matcher, json=project)
+        assert organization.projects.get(
+            "6d5813be-7e6d-4ab8-80c2-1e3e2a454545"
+        ).tags.all() == [{"key": "some-key", "value": "some-value"}]
+
 
 class TestProject(TestModels):
     @pytest.fixture


### PR DESCRIPTION
fixes: #157 - when getting a project by id the ProjectManager.get() was not adding the _tags field like the Project model expects. This resulted in an empty array being returned when calling project.tags.all()
This adds the same logic as ProjectManager.query()