### PR TITLE
Translate Project None to int

### DIFF
--- a/snyk/managers.py
+++ b/snyk/managers.py
@@ -160,6 +160,8 @@ class ProjectManager(Manager):
                         del project_data["tags"]
                     except KeyError:
                         pass
+                    if project_data['totalDependencies'] is None:
+                        project_data['totalDependencies'] = 0
                     projects.append(self.klass.from_dict(project_data))
             for x in projects:
                 x.organization = self.instance


### PR DESCRIPTION
Perform Project data validation so that None is translate to int.

This solves the following error:

```
mashumaro.exceptions.InvalidFieldValue: Field "totalDependencies" of type int in Project has invalid value None
```