### PR TITLE
Fix #175 - add `owner` and `importingUser` attributes to Project Class

### DIFF
--- a/snyk/models.py
+++ b/snyk/models.py
@@ -587,6 +587,8 @@ class Project(DataClassJSONMixin):
     attributes: Optional[Dict[str, List[str]]] = None
     _tags: Optional[List[Any]] = field(default_factory=list)
     remediation: Optional[Dict[Any, Any]] = field(default_factory=dict)
+    owner: Optional[Dict[Any, Any]] = field(default_factory=dict)
+    importingUser: Optional[Dict[Any, Any]] = field(default_factory=dict)
 
     def delete(self) -> bool:
         path = "org/%s/project/%s" % (self.organization.id, self.id)


### PR DESCRIPTION
With the code below, `project1.importingUser` now has information, e.g.
```
>>> project1.importingUser
{'id': 'my-id', 'name': 'John Constable', 'username': 'john', 'email': 'my@email'}
```

```
import os
import snyk

if "SNYK_TOKEN" in os.environ:
    SNYK_TOKEN = os.getenv("SNYK_TOKEN")
else:
    print("Missing Snyk Token")
    print(
        "generate one for Sanger Institute Organization at https://docs.snyk.io/snyk-api-info/authentication-for-api"
    )
    exit

client = snyk.SnykClient(SNYK_TOKEN)
projects = client.projects.all()
project1 = projects[0]
project1.importingUser
project1.owner
```