### PR TITLE
Add `cvssDetails` to IssueData 

### DIFF
--- a/examples/api-demo-2c-list-issues-aggregated.py
+++ b/examples/api-demo-2c-list-issues-aggregated.py
@@ -69,6 +69,10 @@ for v in issue_set.issues:
     print("  Severity: %s" % v.issueData.severity)
     print("  CVSS Score: %s" % v.issueData.cvssScore)
 
+    # print CVSS assigners if exists
+    for detail in v.issueData.cvssDetails:
+        print("    %s score: %s" % (detail['assigner'], detail['cvssV3BaseScore']))
+
     # for the excel output
     new_output_item = {
         "title": v.issueData.title,

--- a/snyk/models.py
+++ b/snyk/models.py
@@ -90,6 +90,7 @@ class IssueData(DataClassJSONMixin):
     disclosureTime: Optional[str] = None
     CVSSv3: Optional[str] = None
     cvssScore: Optional[str] = None
+    cvssDetails: Optional[List[Any]] = None
     language: Optional[str] = None
     patches: Optional[Any] = None
     nearestFixedInVersion: Optional[str] = None


### PR DESCRIPTION
I think it's useful for the user to be able to get information about the NVD's CVSS score etc, but why is this a hidden (undocumented) attribute?

example:
```
$ python examples/api-demo-2c-list-issues-aggregated.py --orgId $ORG_ID --projectId $PRJ_ID

 SQL Injection
  id: SNYK-UNMANAGED-POSTGRESQL-2336056
  url: https://snyk.io/vuln/SNYK-UNMANAGED-POSTGRESQL-2336056
  https://ftp.postgresql.org|postgresql@['9.6.1']
  Severity: critical
  CVSS Score: 9.8
    NVD score: 9.8
    Red Hat score: 8
    SUSE score: 9.8
<...>
```