### PR TITLE
fix/correct isMonitored project attribute

### DIFF
--- a/snyk/managers.py
+++ b/snyk/managers.py
@@ -152,9 +152,7 @@ class ProjectManager(Manager):
             "type": attributes.get("type"),
             "readOnly": attributes.get("read_only"),
             "testFrequency": recurring_tests.get("frequency"),
-            "isMonitored": True
-            if attributes.get("status") == "active"
-            else False,
+            "isMonitored": True if attributes.get("status") == "active" else False,
             "issueCountsBySeverity": {
                 "low": issue_counts.get("low"),
                 "medium": issue_counts.get("medium"),

--- a/snyk/managers.py
+++ b/snyk/managers.py
@@ -153,7 +153,7 @@ class ProjectManager(Manager):
             "readOnly": attributes.get("read_only"),
             "testFrequency": recurring_tests.get("frequency"),
             "isMonitored": True
-            if project.get("meta", {}).get("cli_monitored_at")
+            if attributes.get("status") == "active"
             else False,
             "issueCountsBySeverity": {
                 "low": issue_counts.get("low"),


### PR DESCRIPTION
The isMonitored project attribute was checking weather a project was monitored by CLI or not but this needs to represent the status of the project (whether it is active or not)