### PR TITLE
Update pyproject.toml with broader `importlib-metadata` version specifier

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,7 +16,7 @@ repository = "https://github.com/snyk-labs/pysnyk"
 python = "^3.7"
 requests = "^2.27.1"
 mashumaro = "^3"
-importlib_metadata = "^4.11.2"
+importlib-metadata = ">=4.11.2,<7"
 retry = "^0.9.2"
 deprecation = "^2.1.0"
 


### PR DESCRIPTION
This patch addresses #192 and the functionality being used by pysnyk exists and functions the same in all versions of `importlib-metadata` within the specifier.

