### PR TITLE
feat: include image cluster in V1 backfill for feature parity

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pysnyk"
-version = "0.9.14"
+version = "0.9.15"
 description = "A Python client for the Snyk API"
 authors = [
   "Gareth Rushgrove <garethr@snyk.io>",

--- a/snyk/managers.py
+++ b/snyk/managers.py
@@ -151,6 +151,14 @@ class ProjectManager(Manager):
             .get("attributes", {})
             .get("url")
         )
+        image_cluster = (
+            project.get("relationships", {})
+            .get("target", {})
+            .get("data", {})
+            .get("meta", {})
+            .get("integration_data", {})
+            .get("cluster")
+        )
         return {
             "name": attributes.get("name"),
             "id": project.get("id"),
@@ -169,6 +177,7 @@ class ProjectManager(Manager):
             "targetReference": attributes.get("target_reference"),
             "branch": attributes.get("target_reference"),
             "remoteRepoUrl": remote_repo_url,
+            "imageCluster": image_cluster,
             "_tags": attributes.get("tags", []),
             "importingUserId": project.get("relationships", {})
             .get("importer", {})


### PR DESCRIPTION
https://github.com/snyk-labs/pysnyk/issues/199
SInce the recent release of REST API to include image cluster data, we can now map this back for v1 backward compatibility.