### PR TITLE
Fix issue with limit duplication leading to errors

### DIFF
--- a/snyk/client.py
+++ b/snyk/client.py
@@ -1,6 +1,7 @@
 import logging
 import urllib.parse
 from typing import Any, List, Optional
+from urllib.parse import parse_qs, urlparse
 
 import requests
 from retry.api import retry_call
@@ -161,6 +162,11 @@ class SnykClient(object):
             for k, v in params.items():
                 if isinstance(v, bool):
                     params[k] = str(v).lower()
+
+            # the limit is returned in the url, and if two limits are passed
+            # the API interprets as an array and throws an error
+            if "limit" in parse_qs(urlparse(path).query):
+                params.pop("limit", None)
 
             debug_url = f"{url}&{urllib.parse.urlencode(params)}"
             fkwargs = {"headers": self.api_headers, "params": params}

--- a/snyk/managers.py
+++ b/snyk/managers.py
@@ -191,9 +191,7 @@ class ProjectManager(Manager):
 
     def _query(self, tags: List[Dict[str, str]] = [], next_url: str = None):
         projects = []
-        params: dict = {
-            "limit": 100,
-        }
+        params: dict = {"limit": 100}
         if self.instance:
             path = "/orgs/%s/projects" % self.instance.id if not next_url else next_url
 

--- a/snyk/test_client.py
+++ b/snyk/test_client.py
@@ -322,3 +322,10 @@ class TestSnykClient(object):
         data = rest_client.get_rest_pages(f"orgs/{V3_ORG}/targets", t_params)
 
         assert len(data) == 30
+
+    def test_rest_limit_deduplication(self, requests_mock, rest_client):
+        requests_mock.get(
+            f"{REST_URL}/orgs/{REST_ORG}/projects?limit=100&version={REST_VERSION}"
+        )
+        params = {"limit": 10}
+        rest_client.get(f"orgs/{REST_ORG}/projects?limit=100", params)


### PR DESCRIPTION
[this commit](https://github.com/snyk-labs/pysnyk/commit/dc75bc926aa369d7d39e89e744b3b07d6af0fb0f) introduced a default limit in the client. However, the limit is also present in the URL. That leads to the 2nd and subsequent pages failing due to passing `limit=X&limit=X`. That is interpreted as an array by the server, and will fail with a client error.

The fix checks the URL for the limit, and avoids the duplication if present.