### PR TITLE
Enhancement: Make REST_API_URL Customizable in SnykClient Constructor

### DIFF
--- a/snyk/client.py
+++ b/snyk/client.py
@@ -24,6 +24,7 @@ class SnykClient(object):
         self,
         token: str,
         url: Optional[str] = None,
+        rest_api_url: Optional[str] = None,
         user_agent: Optional[str] = USER_AGENT,
         debug: bool = False,
         tries: int = 1,
@@ -34,6 +35,7 @@ class SnykClient(object):
     ):
         self.api_token = token
         self.api_url = url or self.API_URL
+        self.rest_api_url = rest_api_url or self.REST_API_URL
         self.api_headers = {
             "Authorization": "token %s" % self.api_token,
             "User-Agent": user_agent,
@@ -45,10 +47,13 @@ class SnykClient(object):
         self.delay = delay
         self.verify = verify
         self.version = version
+
         # Ensure we don't have a trailing /
         if self.api_url[-1] == "/":
             self.api_url = self.api_url.rstrip("/")
-
+        if self.rest_api_url[-1] == "/":
+            self.rest_api_url = self.rest_api_url.rstrip("/")
+        
         if debug:
             logging.basicConfig(level=logging.DEBUG)
 
@@ -141,9 +146,9 @@ class SnykClient(object):
             # When calling a "next page" link, it fails if a version parameter is appended on to the URL - this is a
             # workaround to prevent that from happening...
             if exclude_version:
-                url = f"{self.REST_API_URL}/{path}"
+                url = f"{self.rest_api_url}/{path}"
             else:
-                url = f"{self.REST_API_URL}/{path}?version={version}"
+                url = f"{self.rest_api_url}/{path}?version={version}"
         else:
             url = f"{self.api_url}/{path}"
 


### PR DESCRIPTION
**Modification of REST_API_URL to be customizable**

### Description of Changes

In this modification, I have made the `REST_API_URL` variable customizable when creating an instance of the `SnykClient` class. Previously, this URL was statically defined within the class, but now users can specify a different URL for the REST API by passing the desired value as an argument when creating the `SnykClient` object. This flexibility will allow users to choose the REST API URL that best suits their needs.

### Technical Details

- Added the `rest_api_url` argument to the constructor of the `SnykClient` class.
- Used this argument to initialize the `REST_API_URL` variable if a value is provided, otherwise the default value is used.

### Context

This modification was made to enable users to customize the REST API URL when using the `pysnyk` library. It provides more flexibility for developers who want to interact with different instances of the Snyk API.

### How to Test

This modification does not impact the existing functionality of the library. You can still create an instance of the `SnykClient` class by passing a different value for `rest_api_url` and verify that the customized URL is used for REST API requests.

### Example Usage

```python
client = SnykClient(token=api_key, url="https://app.eu.snyk.io/api/", rest_api_url="https://api.eu.snyk.io/rest")

# Now, the client will use the customized URL for the REST API
