### PR TITLE
Enhancement: Get lastTestedDate from latest_issue_counts.updated_at instead of snapshot

### DIFF
--- a/snyk/managers.py
+++ b/snyk/managers.py
@@ -167,6 +167,7 @@ class ProjectManager(Manager):
             "type": attributes.get("type"),
             "readOnly": attributes.get("read_only"),
             "testFrequency": recurring_tests.get("frequency"),
+            "lastTestedDate": issue_counts.get("updated_at"),
             "isMonitored": True if attributes.get("status") == "active" else False,
             "issueCountsBySeverity": {
                 "low": issue_counts.get("low", 0),

--- a/snyk/models.py
+++ b/snyk/models.py
@@ -580,6 +580,7 @@ class Project(DataClassJSONMixin):
     type: str
     readOnly: bool
     testFrequency: str
+    lastTestedDate: str
     isMonitored: bool
     issueCountsBySeverity: IssueCounts
     importingUserId: Optional[str] = None
@@ -643,7 +644,6 @@ class Project(DataClassJSONMixin):
         # These attributes require us to get the latest snapshot
         if item in [
             "totalDependencies",
-            "lastTestedDate",
             "imageId",
             "imageTag",
             "imageBaseImage",
@@ -652,8 +652,6 @@ class Project(DataClassJSONMixin):
             snapshot = self._get_project_snapshot()
             if item == "totalDependencies":
                 return snapshot.get("totalDependencies", 0)
-            elif item == "lastTestedDate":
-                return snapshot.get("created")
             elif item == "imageId":
                 return snapshot.get("imageId")
             elif item == "imageTag":


### PR DESCRIPTION
There is no reason to require an extra API call for this attribute, since it is already pulled in the initial projects call. 