### PR TITLE
Add override for REST API URL

### DIFF
--- a/snyk/client.py
+++ b/snyk/client.py
@@ -24,6 +24,7 @@ class SnykClient(object):
         self,
         token: str,
         url: Optional[str] = None,
+        rest_url: Optional[str] = None,
         user_agent: Optional[str] = USER_AGENT,
         debug: bool = False,
         tries: int = 1,
@@ -34,6 +35,7 @@ class SnykClient(object):
     ):
         self.api_token = token
         self.api_url = url or self.API_URL
+        self.rest_api_url = rest_url or self.REST_API_URL
         self.api_headers = {
             "Authorization": "token %s" % self.api_token,
             "User-Agent": user_agent,
@@ -141,9 +143,9 @@ class SnykClient(object):
             # When calling a "next page" link, it fails if a version parameter is appended on to the URL - this is a
             # workaround to prevent that from happening...
             if exclude_version:
-                url = f"{self.REST_API_URL}/{path}"
+                url = f"{self.rest_api_url}/{path}"
             else:
-                url = f"{self.REST_API_URL}/{path}?version={version}"
+                url = f"{self.rest_api_url}/{path}?version={version}"
         else:
             url = f"{self.api_url}/{path}"
 

--- a/snyk/test_client.py
+++ b/snyk/test_client.py
@@ -33,6 +33,14 @@ class TestSnykClient(object):
         client = SnykClient("token", url)
         assert client.api_url == url
 
+    def test_default_rest_api_url(self, client):
+        assert client.rest_api_url == "https://api.snyk.io/rest"
+
+    def test_overriding_rest_api_url(self):
+        rest_url = "https://api.notsnyk.io/rest"
+        client = SnykClient("token", rest_url=rest_url)
+        assert client.rest_api_url == rest_url
+
     def test_token_added_to_headers(self, client):
         assert client.api_headers["Authorization"] == "token token"
 


### PR DESCRIPTION
This PR adds support to override the REST API URL variable.
Implementation is identical to the existing URL override.

This option is not optimal, a general override host is probably a more general solution, however the proposed solution will not result a breaking change.

Added tests to validate changes