### PR TITLE
Add support to Github Enterprise

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ The client supports a high-level `import_project` method on organizations for ad
 ```python
 org = client.organizations.first()
 org.import_project("github.com/user/project@branch")
+org.import_project("api.github.com/user/project@branch")  # Github Enterprise
 org.import_project("docker.io/repository:tag")
 ```
 


### PR DESCRIPTION
Hello everyone,

I encountered some difficulties using the pysnyk library with GitHub Enterprise, so I ended up making this code change that made it work (at least for what I needed). I believe it might be helpful.
I couldn't find any open issues on the topic. Feel free to close the PR if it's not relevant.
Also, I may have missed something, so any suggestions for corrections or improvements will be appreciated.

Thank you.


## About the change:

The Snyk API calls to import projects from "github.com" and "api.github.com" seem to be the same. I was able to make it work with the following snippet:
```python
def import_github_repo(snyk_org_id, github_org_name, repo_name, branch):
    org = get_snyk_client().organizations.get(snyk_org_id)
    integration = org.integrations.filter(name="github-enterprise")[0]
    return integration.import_git(github_org_name, repo_name, branch)
```
To automate this and make it work with `import_project`, I added support for handling "api.github.com" and detecting the integration associated with `github-enterprise` when necessary. This will make it possible to capture the correct Integration ID and make the call to import_git seamlessly. 
