### PR TITLE
add version param support for REST delete calls

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,16 @@
+# Getting started
+
+This project uses Poetry. Install the dependencies using:
+
+```
+poetry install
+```
+
+## Running the tests
+
+To run the test suite, use the following command:
+
+
+```
+poetry run pytest
+```

--- a/snyk/client.py
+++ b/snyk/client.py
@@ -196,14 +196,30 @@ class SnykClient(object):
 
         return resp
 
-    def delete(self, path: str) -> requests.Response:
-        url = f"{self.api_url}/{path}"
+    def delete(
+        self,
+        path: str,
+        version: str = None,
+    ) -> requests.Response:
+        if version:
+            url = f"{self.rest_api_url}/{path}?version={version}"
+        else:
+            url = f"{self.api_url}/{path}"
+
         logger.debug(f"DELETE: {url}")
+
+        if version or self.version:
+            params = {}
+            params["version"] = version or self.version
+
+            fkwargs = {"headers": self.api_headers, "params": params}
+        else:
+            fkwargs = {"headers": self.api_headers}
 
         resp = retry_call(
             self.request,
             fargs=[requests.delete, url],
-            fkwargs={"headers": self.api_headers},
+            fkwargs=fkwargs,
             tries=self.tries,
             delay=self.delay,
             backoff=self.backoff,

--- a/snyk/test_client.py
+++ b/snyk/test_client.py
@@ -12,6 +12,7 @@ from snyk.utils import load_test_data
 TEST_DATA = os.path.join(os.path.dirname(__file__), "test_data")
 
 REST_ORG = "39ddc762-b1b9-41ce-ab42-defbe4575bd6"
+REST_PROJECT = "1ae27847-83d0-40f8-be5c-93438336cc3e"
 REST_URL = "https://api.snyk.io/rest"
 REST_VERSION = "2022-02-16~experimental"
 
@@ -296,6 +297,17 @@ class TestSnykClient(object):
         targets = rest_client.get(f"orgs/{REST_ORG}/targets", t_params).json()
 
         assert len(targets["data"]) == 10
+
+    def test_rest_delete(self, requests_mock, rest_client, rest_targets_page1):
+        requests_mock.delete(
+            f"{REST_URL}/orgs/{REST_ORG}/projects/{REST_PROJECT}?version={REST_VERSION}",
+            status_code=204,
+            json={},
+        )
+
+        rest_client.delete(f"orgs/{REST_ORG}/projects/{REST_PROJECT}")
+
+        assert requests_mock.call_count == 1
 
     def test_get_rest_pages(
         self,


### PR DESCRIPTION
Currently, the REST API calls via pysnyk do not work because of a missing version header. This copies the code from `get` and also adds support for manual version specification.