### PR TITLE
Enhancement: clients can use REST url for all methods

### DIFF
--- a/examples/api-demo-1-list-projects.py
+++ b/examples/api-demo-1-list-projects.py
@@ -17,10 +17,16 @@ snyk_token = get_token(snyk_token_path)
 args = parse_command_line_args()
 org_id = args.orgId
 
-client = SnykClient(token=snyk_token)
+client = SnykClient(token=snyk_token, debug=True)
 for proj in client.organizations.get(org_id).projects.all():
     print("\nProject name: %s" % proj.name)
+    print("Project id: %s" % proj.id)
     print("  Issues Found:")
     print("      High  : %s" % proj.issueCountsBySeverity.high)
     print("      Medium: %s" % proj.issueCountsBySeverity.medium)
     print("      Low   : %s" % proj.issueCountsBySeverity.low)
+
+proj1 = client.projects.get("df7667d2-a79f-47ce-875b-99c93bf45426")
+proj2 = client.organizations.get(org_id).projects.get(proj1.id)
+print(proj1)
+print(proj2)

--- a/examples/api-demo-1-list-projects.py
+++ b/examples/api-demo-1-list-projects.py
@@ -17,16 +17,10 @@ snyk_token = get_token(snyk_token_path)
 args = parse_command_line_args()
 org_id = args.orgId
 
-client = SnykClient(token=snyk_token, debug=True)
+client = SnykClient(token=snyk_token)
 for proj in client.organizations.get(org_id).projects.all():
     print("\nProject name: %s" % proj.name)
-    print("Project id: %s" % proj.id)
     print("  Issues Found:")
     print("      High  : %s" % proj.issueCountsBySeverity.high)
     print("      Medium: %s" % proj.issueCountsBySeverity.medium)
     print("      Low   : %s" % proj.issueCountsBySeverity.low)
-
-proj1 = client.projects.get("df7667d2-a79f-47ce-875b-99c93bf45426")
-proj2 = client.organizations.get(org_id).projects.get(proj1.id)
-print(proj1)
-print(proj2)

--- a/snyk/client.py
+++ b/snyk/client.py
@@ -1,7 +1,7 @@
 import logging
 import re
 import urllib.parse
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 from urllib.parse import parse_qs, urlparse
 
 import requests
@@ -98,6 +98,28 @@ class SnykClient(object):
             delay=self.delay,
             backoff=self.backoff,
             exceptions=SnykHTTPError,
+            logger=logger,
+        )
+
+        if not resp.ok:
+            logger.error(resp.text)
+            raise SnykHTTPError(resp)
+
+        return resp
+
+    def patch(
+        self, path: str, body: Dict[str, Any], headers: Dict[str, str] = {}
+    ) -> requests.Response:
+        url = f"{self.rest_api_url}/{path}"
+        logger.debug(f"PATCH: {url}")
+
+        resp = retry_call(
+            self.request,
+            fargs=[requests.patch, url],
+            fkwargs={"json": body, "headers": {**self.api_post_headers, **headers}},
+            tries=self.tries,
+            delay=self.delay,
+            backoff=self.backoff,
             logger=logger,
         )
 

--- a/snyk/client.py
+++ b/snyk/client.py
@@ -42,9 +42,9 @@ class SnykClient(object):
             "Authorization": "token %s" % self.api_token,
             "User-Agent": user_agent,
         }
-        self.api_post_headers = copy.deepcopy(self.api_headers)
+        self.api_post_headers = dict(self.api_headers)
         self.api_post_headers["Content-Type"] = "application/json"
-        self.api_patch_headers = copy.deepcopy(self.api_headers)
+        self.api_patch_headers = dict(self.api_headers)
         self.api_patch_headers["Content-Type"] = "application/vnd.api+json"
         self.tries = tries
         self.backoff = backoff
@@ -54,6 +54,7 @@ class SnykClient(object):
         self.__uuid_pattern = (
             r"[0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
         )
+        self.__latest_version = "2024-06-21"
 
         # Ensure we don't have a trailing /
         if self.api_url[-1] == "/":
@@ -93,7 +94,7 @@ class SnykClient(object):
         self,
         path: str,
         body: Any,
-        headers: dict = {},
+        headers: Dict = {},
         params: Dict[str, Any] = {},
         use_rest: bool = False,
     ) -> requests.Response:
@@ -101,7 +102,7 @@ class SnykClient(object):
         logger.debug(f"POST: {url}")
 
         if use_rest and "version" not in params:
-            params["version"] = self.version if self.version else "2024-06-21"
+            params["version"] = self.version or self.__latest_version
 
         resp = retry_call(
             self.request,
@@ -135,7 +136,7 @@ class SnykClient(object):
         logger.debug(f"PATCH: {url}")
 
         if "version" not in params:
-            params["version"] = self.version if self.version else "2024-06-21"
+            params["version"] = self.version or self.__latest_version
 
         resp = retry_call(
             self.request,
@@ -161,7 +162,7 @@ class SnykClient(object):
         self,
         path: str,
         body: Any,
-        headers: dict = {},
+        headers: Dict = {},
         params: Dict[str, Any] = {},
         use_rest: bool = False,
     ) -> requests.Response:
@@ -172,7 +173,7 @@ class SnykClient(object):
         logger.debug("PUT: %s" % url)
 
         if use_rest and "version" not in params:
-            params["version"] = self.version if self.version else "2024-06-21"
+            params["version"] = self.version or self.__latest_version
 
         resp = retry_call(
             self.request,
@@ -196,7 +197,7 @@ class SnykClient(object):
     def get(
         self,
         path: str,
-        params: dict = None,
+        params: Dict = None,
         version: str = None,
         exclude_version: bool = False,
         exclude_params: bool = False,
@@ -279,7 +280,7 @@ class SnykClient(object):
 
         params = {}
         if use_rest:
-            params["version"] = self.version if self.version else "2024-06-21"
+            params["version"] = self.version or self.__latest_version
 
         logger.debug(f"DELETE: {url}")
 
@@ -298,7 +299,7 @@ class SnykClient(object):
 
         return resp
 
-    def get_rest_pages(self, path: str, params: dict = {}) -> List:
+    def get_rest_pages(self, path: str, params: Dict = {}) -> List:
         """
         Helper function to collect paginated responses from the rest API into a single
         list.

--- a/snyk/client.py
+++ b/snyk/client.py
@@ -1,6 +1,6 @@
 import logging
 import urllib.parse
-from typing import Any, List, Optional
+from typing import Any, List, Optional, Dict
 from urllib.parse import parse_qs, urlparse
 
 import requests
@@ -21,17 +21,17 @@ class SnykClient(object):
     USER_AGENT = "pysnyk/%s" % __version__
 
     def __init__(
-        self,
-        token: str,
-        url: Optional[str] = None,
-        rest_api_url: Optional[str] = None,
-        user_agent: Optional[str] = USER_AGENT,
-        debug: bool = False,
-        tries: int = 1,
-        delay: int = 1,
-        backoff: int = 2,
-        verify: bool = True,
-        version: Optional[str] = None,
+            self,
+            token: str,
+            url: Optional[str] = None,
+            rest_api_url: Optional[str] = None,
+            user_agent: Optional[str] = USER_AGENT,
+            debug: bool = False,
+            tries: int = 1,
+            delay: int = 1,
+            backoff: int = 2,
+            verify: bool = True,
+            version: Optional[str] = None,
     ):
         self.api_token = token
         self.api_url = url or self.API_URL
@@ -58,12 +58,12 @@ class SnykClient(object):
             logging.basicConfig(level=logging.DEBUG)
 
     def request(
-        self,
-        method,
-        url: str,
-        headers: object,
-        params: object = None,
-        json: object = None,
+            self,
+            method,
+            url: str,
+            headers: object,
+            params: object = None,
+            json: object = None,
     ) -> requests.Response:
 
         if params and json:
@@ -123,12 +123,12 @@ class SnykClient(object):
         return resp
 
     def get(
-        self,
-        path: str,
-        params: dict = None,
-        version: str = None,
-        exclude_version: bool = False,
-        exclude_params: bool = False,
+            self,
+            path: str,
+            params: dict = None,
+            version: str = None,
+            exclude_version: bool = False,
+            exclude_params: bool = False,
     ) -> requests.Response:
         """
         Rest (formerly v3) Compatible Snyk Client, assumes the presence of Version, either set in the client
@@ -236,8 +236,8 @@ class SnykClient(object):
             if "next" in page_data["links"]:
                 # If the next url is the same as the current url, break out of the loop
                 if (
-                    "self" in page_data["links"]
-                    and page_data["links"]["next"] == page_data["links"]["self"]
+                        "self" in page_data["links"]
+                        and page_data["links"]["next"] == page_data["links"]["self"]
                 ):
                     break
                 else:
@@ -293,3 +293,9 @@ class SnykClient(object):
     # https://snyk.docs.apiary.io/#reference/reporting-api/issues/get-list-of-issues
     def issues(self):
         raise SnykNotImplementedError  # pragma: no cover
+
+
+    def __convert_v1_to_rest_endpoint(self, path: str) -> str:
+        uuid_pattern = r'[0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}'
+
+

--- a/snyk/client.py
+++ b/snyk/client.py
@@ -22,17 +22,17 @@ class SnykClient(object):
     USER_AGENT = "pysnyk/%s" % __version__
 
     def __init__(
-            self,
-            token: str,
-            url: Optional[str] = None,
-            rest_api_url: Optional[str] = None,
-            user_agent: Optional[str] = USER_AGENT,
-            debug: bool = False,
-            tries: int = 1,
-            delay: int = 1,
-            backoff: int = 2,
-            verify: bool = True,
-            version: Optional[str] = None,
+        self,
+        token: str,
+        url: Optional[str] = None,
+        rest_api_url: Optional[str] = None,
+        user_agent: Optional[str] = USER_AGENT,
+        debug: bool = False,
+        tries: int = 1,
+        delay: int = 1,
+        backoff: int = 2,
+        verify: bool = True,
+        version: Optional[str] = None,
     ):
         self.api_token = token
         self.api_url = url or self.API_URL
@@ -48,7 +48,9 @@ class SnykClient(object):
         self.delay = delay
         self.verify = verify
         self.version = version
-        self.__uuid_pattern = r'[0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}'
+        self.__uuid_pattern = (
+            r"[0-9a-f]{8}-[0-9a-f]{4}-[4][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}"
+        )
 
         # Ensure we don't have a trailing /
         if self.api_url[-1] == "/":
@@ -60,12 +62,12 @@ class SnykClient(object):
             logging.basicConfig(level=logging.DEBUG)
 
     def request(
-            self,
-            method,
-            url: str,
-            headers: object,
-            params: object = None,
-            json: object = None,
+        self,
+        method,
+        url: str,
+        headers: object,
+        params: object = None,
+        json: object = None,
     ) -> requests.Response:
 
         if params and json:
@@ -125,12 +127,12 @@ class SnykClient(object):
         return resp
 
     def get(
-            self,
-            path: str,
-            params: dict = None,
-            version: str = None,
-            exclude_version: bool = False,
-            exclude_params: bool = False,
+        self,
+        path: str,
+        params: dict = None,
+        version: str = None,
+        exclude_version: bool = False,
+        exclude_params: bool = False,
     ) -> requests.Response:
         """
         Rest (formerly v3) Compatible Snyk Client, assumes the presence of Version, either set in the client
@@ -246,8 +248,8 @@ class SnykClient(object):
             if "next" in page_data["links"]:
                 # If the next url is the same as the current url, break out of the loop
                 if (
-                        "self" in page_data["links"]
-                        and page_data["links"]["next"] == page_data["links"]["self"]
+                    "self" in page_data["links"]
+                    and page_data["links"]["next"] == page_data["links"]["self"]
                 ):
                     break
                 else:

--- a/snyk/client.py
+++ b/snyk/client.py
@@ -93,7 +93,7 @@ class SnykClient(object):
     def post(
         self,
         path: str,
-        body: Any,
+        body: Dict[str, Any],
         headers: Dict = {},
         params: Dict[str, Any] = {},
         use_rest: bool = False,

--- a/snyk/client.py
+++ b/snyk/client.py
@@ -175,15 +175,19 @@ class SnykClient(object):
         )
         logger.debug("PUT: %s" % url)
 
-        if use_rest and "version" not in params:
-            params["version"] = self.version or self.__latest_version
+        request_headers = {**self.api_post_headers, **headers}
+
+        if use_rest:
+            if "version" not in params:
+                params["version"] = self.version or self.__latest_version
+            request_headers["Content-Type"] = "application/vnd.api+json"
 
         resp = retry_call(
             self.request,
             fargs=[requests.put, url],
             fkwargs={
                 "json": body,
-                "headers": {**self.api_post_headers, **headers},
+                "headers": request_headers,
                 "params": params,
             },
             tries=self.tries,

--- a/snyk/client.py
+++ b/snyk/client.py
@@ -108,15 +108,26 @@ class SnykClient(object):
         return resp
 
     def patch(
-        self, path: str, body: Dict[str, Any], headers: Dict[str, str] = {}
+        self,
+        path: str,
+        body: Dict[str, Any],
+        headers: Dict[str, str] = {},
+        params: Dict[str, Any] = {},
     ) -> requests.Response:
         url = f"{self.rest_api_url}/{path}"
         logger.debug(f"PATCH: {url}")
 
+        if "version" not in params:
+            params["version"] = self.version if self.version else "2024-06-21"
+
         resp = retry_call(
             self.request,
             fargs=[requests.patch, url],
-            fkwargs={"json": body, "headers": {**self.api_post_headers, **headers}},
+            fkwargs={
+                "json": body,
+                "headers": {**self.api_post_headers, **headers},
+                "params": params,
+            },
             tries=self.tries,
             delay=self.delay,
             backoff=self.backoff,

--- a/snyk/client.py
+++ b/snyk/client.py
@@ -230,7 +230,6 @@ class SnykClient(object):
             url = f"{self.rest_api_url}/{path}"
         else:
             url = f"{self.api_url}/{path}"
-        # url = f"{self.api_url}/{path}"
 
         logger.debug(f"DELETE: {url}")
 

--- a/snyk/client.py
+++ b/snyk/client.py
@@ -101,15 +101,18 @@ class SnykClient(object):
         url = f"{self.rest_api_url if use_rest else self.api_url}/{path}"
         logger.debug(f"POST: {url}")
 
-        if use_rest and "version" not in params:
-            params["version"] = self.version or self.__latest_version
+        request_headers = {**self.api_post_headers, **headers}
+        if use_rest:
+            if "version" not in params:
+                params["version"] = self.version or self.__latest_version
+            request_headers["Content-Type"] = "application/vnd.api+json"
 
         resp = retry_call(
             self.request,
             fargs=[requests.post, url],
             fkwargs={
                 "json": body,
-                "headers": {**self.api_post_headers, **headers},
+                "headers": request_headers,
                 "params": params,
             },
             tries=self.tries,

--- a/snyk/client.py
+++ b/snyk/client.py
@@ -86,14 +86,28 @@ class SnykClient(object):
             raise SnykHTTPError(resp)
         return resp
 
-    def post(self, path: str, body: Any, headers: dict = {}) -> requests.Response:
-        url = f"{self.api_url}/{path}"
+    def post(
+        self,
+        path: str,
+        body: Any,
+        headers: dict = {},
+        params: Dict[str, Any] = {},
+        use_rest: bool = False,
+    ) -> requests.Response:
+        url = f"{self.rest_api_url if use_rest else self.api_url}/{path}"
         logger.debug(f"POST: {url}")
+
+        if use_rest and "version" not in params:
+            params["version"] = self.version if self.version else "2024-06-21"
 
         resp = retry_call(
             self.request,
             fargs=[requests.post, url],
-            fkwargs={"json": body, "headers": {**self.api_post_headers, **headers}},
+            fkwargs={
+                "json": body,
+                "headers": {**self.api_post_headers, **headers},
+                "params": params,
+            },
             tries=self.tries,
             delay=self.delay,
             backoff=self.backoff,
@@ -140,14 +154,31 @@ class SnykClient(object):
 
         return resp
 
-    def put(self, path: str, body: Any, headers: dict = {}) -> requests.Response:
-        url = "%s/%s" % (self.api_url, path)
+    def put(
+        self,
+        path: str,
+        body: Any,
+        headers: dict = {},
+        params: Dict[str, Any] = {},
+        use_rest: bool = False,
+    ) -> requests.Response:
+        url = "%s/%s" % (
+            self.rest_api_url if use_rest else self.api_url,
+            path,
+        )
         logger.debug("PUT: %s" % url)
+
+        if use_rest and "version" not in params:
+            params["version"] = self.version if self.version else "2024-06-21"
 
         resp = retry_call(
             self.request,
             fargs=[requests.put, url],
-            fkwargs={"json": body, "headers": {**self.api_post_headers, **headers}},
+            fkwargs={
+                "json": body,
+                "headers": {**self.api_post_headers, **headers},
+                "params": params,
+            },
             tries=self.tries,
             delay=self.delay,
             backoff=self.backoff,

--- a/snyk/managers.py
+++ b/snyk/managers.py
@@ -255,25 +255,22 @@ class ProjectManager(Manager):
 
     def get(self, id: str):
         if self.instance:
-            path = "orgs/%s/projects/%s" % (self.instance.id, id)
-            params = {"expand": "target", "meta.latest_issue_counts": "true"}
-            resp = self.client.get(path, version="2024-06-21", params=params)
-            response_json = resp.json()
-            if "data" in response_json:
-                project_data = self._rest_to_v1_response_format(response_json["data"])
-                project_data["organization"] = self.instance.to_dict()
-                # We move tags to _tags as a cache, to avoid the need for additional requests
-                # when working with tags. We want tags to be the manager
-                try:
-                    project_data["_tags"] = project_data["tags"]
-                    del project_data["tags"]
-                except KeyError:
-                    pass
-                if project_data.get("totalDependencies") is None:
-                    project_data["totalDependencies"] = 0
-                project_klass = self.klass.from_dict(project_data)
-                project_klass.organization = self.instance
-                return project_klass
+            path = "org/%s/project/%s" % (self.instance.id, id)
+            resp = self.client.get(path)
+            project_data = resp.json()
+            project_data["organization"] = self.instance.to_dict()
+            # We move tags to _tags as a cache, to avoid the need for additional requests
+            # when working with tags. We want tags to be the manager
+            try:
+                project_data["_tags"] = project_data["tags"]
+                del project_data["tags"]
+            except KeyError:
+                pass
+            if project_data.get("totalDependencies") is None:
+                project_data["totalDependencies"] = 0
+            project_klass = self.klass.from_dict(project_data)
+            project_klass.organization = self.instance
+            return project_klass
         else:
             return super().get(id)
 

--- a/snyk/managers.py
+++ b/snyk/managers.py
@@ -1,5 +1,4 @@
 import abc
-import json
 from typing import Any, Dict, List
 
 from deprecation import deprecated  # type: ignore
@@ -411,9 +410,9 @@ class JiraIssueManager(DictManager):
         # The response we get is not following the schema as specified by the api
         # https://snyk.docs.apiary.io/#reference/projects/project-jira-issues-/create-jira-issue
         if (
-            issue_id in response_data
-            and len(response_data[issue_id]) > 0
-            and "jiraIssue" in response_data[issue_id][0]
+                issue_id in response_data
+                and len(response_data[issue_id]) > 0
+                and "jiraIssue" in response_data[issue_id][0]
         ):
             return response_data[issue_id][0]["jiraIssue"]
         raise SnykError

--- a/snyk/managers.py
+++ b/snyk/managers.py
@@ -410,9 +410,9 @@ class JiraIssueManager(DictManager):
         # The response we get is not following the schema as specified by the api
         # https://snyk.docs.apiary.io/#reference/projects/project-jira-issues-/create-jira-issue
         if (
-                issue_id in response_data
-                and len(response_data[issue_id]) > 0
-                and "jiraIssue" in response_data[issue_id][0]
+            issue_id in response_data
+            and len(response_data[issue_id]) > 0
+            and "jiraIssue" in response_data[issue_id][0]
         ):
             return response_data[issue_id][0]["jiraIssue"]
         raise SnykError

--- a/snyk/models.py
+++ b/snyk/models.py
@@ -3,7 +3,6 @@ import re
 from dataclasses import InitVar, dataclass, field
 from typing import Any, Dict, List, Optional, Union
 
-import requests
 from deprecation import deprecated  # type: ignore
 from mashumaro.mixins.json import DataClassJSONMixin  # type: ignore
 
@@ -245,7 +244,7 @@ class Organization(DataClassJSONMixin):
     # https://snyk.docs.apiary.io/#reference/users/user-organisation-notification-settings/modify-org-notification-settings
     # https://snyk.docs.apiary.io/#reference/users/user-organisation-notification-settings/get-org-notification-settings
     def notification_settings(self):
-        raise SnykNotImplemented  # pragma: no cover
+        raise SnykNotImplementedError  # pragma: no cover
 
     # https://snyk.docs.apiary.io/#reference/organisations/the-snyk-organisation-for-a-request/invite-users
     def invite(self, email: str, admin: bool = False) -> bool:

--- a/snyk/models.py
+++ b/snyk/models.py
@@ -288,7 +288,7 @@ class Organization(DataClassJSONMixin):
         return IssueSet.from_dict(resp.json())
 
     def test_maven(
-        self, package_group_id: str, package_artifact_id: str, version: str
+            self, package_group_id: str, package_artifact_id: str, version: str
     ) -> IssueSet:
         path = "test/maven/%s/%s/%s?org=%s" % (
             package_group_id,
@@ -394,7 +394,7 @@ class Integration(DataClassJSONMixin):
         return bool(self.organization.client.post(path, payload))
 
     def import_git(
-        self, owner: str, name: str, branch: str = "master", files: List[str] = []
+            self, owner: str, name: str, branch: str = "master", files: List[str] = []
     ):
         return self._import(
             {
@@ -418,7 +418,7 @@ class Integration(DataClassJSONMixin):
         )
 
     def import_bitbucket(
-        self, project_key: str, name: str, repo_slug: str, files: List[str] = []
+            self, project_key: str, name: str, repo_slug: str, files: List[str] = []
     ):
         return self._import(
             {
@@ -753,7 +753,7 @@ class Project(DataClassJSONMixin):
         raise SnykNotImplementedError  # pragma: no cover
 
     def _aggregated_issue_to_vulnerabily(
-        self, issue: AggregatedIssue
+            self, issue: AggregatedIssue
     ) -> List[Vulnerability]:
         issue_paths = Manager.factory(
             IssuePaths,
@@ -805,3 +805,25 @@ class Project(DataClassJSONMixin):
             # versions, emulate that here to preserve upstream api
             for version in issue.pkgVersions
         ]
+
+
+class V1ToRestConversion:
+    def __init__(self, v1_path, rest_path, v1_verb, rest_verb):
+        self.v1_path = v1_path
+        self.rest_path = rest_path
+        self.v1_verb = v1_verb
+        self.rest_verb = rest_verb
+
+
+class ProjectV1ToRestConversion(V1ToRestConversion):
+    def convert_delete_request(self):
+        pass
+
+    def convert_add_tag_request(self, body: Dict[str, Any]):
+        pass
+
+    def convert_delete_tag_request(self, body: Dict[str, Any]):
+        pass
+
+    def convert_apply_attributes_request(self, body: Dict[str, Any]):
+        pass

--- a/snyk/models.py
+++ b/snyk/models.py
@@ -804,25 +804,3 @@ class Project(DataClassJSONMixin):
             # versions, emulate that here to preserve upstream api
             for version in issue.pkgVersions
         ]
-
-
-class V1ToRestConversion:
-    def __init__(self, v1_path, rest_path, v1_verb, rest_verb):
-        self.v1_path = v1_path
-        self.rest_path = rest_path
-        self.v1_verb = v1_verb
-        self.rest_verb = rest_verb
-
-
-class ProjectV1ToRestConversion:
-    def convert_delete_request(self):
-        pass
-
-    def convert_add_tag_request(self, body: Dict[str, Any]):
-        pass
-
-    def convert_delete_tag_request(self, body: Dict[str, Any]):
-        pass
-
-    def convert_apply_attributes_request(self, body: Dict[str, Any]):
-        pass

--- a/snyk/models.py
+++ b/snyk/models.py
@@ -815,7 +815,7 @@ class V1ToRestConversion:
         self.rest_verb = rest_verb
 
 
-class ProjectV1ToRestConversion(V1ToRestConversion):
+class ProjectV1ToRestConversion:
     def convert_delete_request(self):
         pass
 

--- a/snyk/models.py
+++ b/snyk/models.py
@@ -287,7 +287,7 @@ class Organization(DataClassJSONMixin):
         return IssueSet.from_dict(resp.json())
 
     def test_maven(
-            self, package_group_id: str, package_artifact_id: str, version: str
+        self, package_group_id: str, package_artifact_id: str, version: str
     ) -> IssueSet:
         path = "test/maven/%s/%s/%s?org=%s" % (
             package_group_id,
@@ -393,7 +393,7 @@ class Integration(DataClassJSONMixin):
         return bool(self.organization.client.post(path, payload))
 
     def import_git(
-            self, owner: str, name: str, branch: str = "master", files: List[str] = []
+        self, owner: str, name: str, branch: str = "master", files: List[str] = []
     ):
         return self._import(
             {
@@ -417,7 +417,7 @@ class Integration(DataClassJSONMixin):
         )
 
     def import_bitbucket(
-            self, project_key: str, name: str, repo_slug: str, files: List[str] = []
+        self, project_key: str, name: str, repo_slug: str, files: List[str] = []
     ):
         return self._import(
             {
@@ -752,7 +752,7 @@ class Project(DataClassJSONMixin):
         raise SnykNotImplementedError  # pragma: no cover
 
     def _aggregated_issue_to_vulnerabily(
-            self, issue: AggregatedIssue
+        self, issue: AggregatedIssue
     ) -> List[Vulnerability]:
         issue_paths = Manager.factory(
             IssuePaths,

--- a/snyk/test_client.py
+++ b/snyk/test_client.py
@@ -335,7 +335,7 @@ class TestSnykClient(object):
     ):
         project = projects["data"][0]
         matcher = re.compile(
-            f"orgs/{REST_ORG}/projects/{project['id']}\\?([^&=]+=[^&=]+&?)+$"
+            f"^{REST_URL}/orgs/{REST_ORG}/projects/{project['id']}\\?([^&=]+=[^&=]+&?)+$"
         )
         body = {
             "data": {
@@ -395,12 +395,12 @@ class TestSnykClient(object):
 
     def test_post_request_rest_api_when_specified(self, requests_mock, client):
         matcher = re.compile(
-            f"{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb\\?version={REST_VERSION}$"
+            f"^{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb\\?version={REST_VERSION}$"
         )
         requests_mock.post(matcher, json={}, status_code=200)
         params = {"version": REST_VERSION}
         client.post(
-            f"{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb",
+            f"orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb",
             body={},
             params=params,
             use_rest=True,
@@ -412,12 +412,12 @@ class TestSnykClient(object):
         self, requests_mock, client
     ):
         matcher = re.compile(
-            f"{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb\\?version={REST_VERSION}$"
+            f"^{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb\\?version={REST_VERSION}$"
         )
         requests_mock.post(matcher, json={}, status_code=200)
         params = {"version": REST_VERSION}
         client.post(
-            f"{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb",
+            f"orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb",
             body={},
             params=params,
             use_rest=True,
@@ -432,12 +432,12 @@ class TestSnykClient(object):
         self, requests_mock, client
     ):
         matcher = re.compile(
-            f"{V1_URL}/org/{REST_ORG}/project/f9fec29a-d288-40d9-a019-cedf825e6efb$"
+            f"^{V1_URL}/org/{REST_ORG}/project/f9fec29a-d288-40d9-a019-cedf825e6efb$"
         )
         requests_mock.post(matcher, json={}, status_code=200)
 
         client.post(
-            f"{V1_URL}/org/{REST_ORG}/project/f9fec29a-d288-40d9-a019-cedf825e6efb",
+            f"org/{REST_ORG}/project/f9fec29a-d288-40d9-a019-cedf825e6efb",
             body={},
             use_rest=False,
         )
@@ -446,12 +446,12 @@ class TestSnykClient(object):
 
     def test_put_request_rest_api_when_specified(self, requests_mock, client):
         matcher = re.compile(
-            f"{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb\\?version={REST_VERSION}$"
+            f"^{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb\\?version={REST_VERSION}$"
         )
         requests_mock.put(matcher, json={}, status_code=200)
         params = {"version": REST_VERSION}
         client.put(
-            f"{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb",
+            f"orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb",
             body={},
             params=params,
             use_rest=True,
@@ -461,7 +461,7 @@ class TestSnykClient(object):
 
     def test_put_request_v1_api_when_specified(self, requests_mock, client):
         matcher = re.compile(
-            f"^https://api.snyk.io/v1/org/{REST_ORG}/project/f9fec29a-d288-40d9-a019-cedf825e6efb"
+            f"^{V1_URL}/org/{REST_ORG}/project/f9fec29a-d288-40d9-a019-cedf825e6efb"
         )
         requests_mock.put(matcher, json={}, status_code=200)
         client.put(
@@ -471,6 +471,42 @@ class TestSnykClient(object):
         )
 
         assert requests_mock.call_count == 1
+
+    def test_put_request_has_rest_content_type_when_specified(
+        self, requests_mock, client
+    ):
+        matcher = re.compile(
+            f"^{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb\\?version={REST_VERSION}$"
+        )
+        requests_mock.put(matcher, json={}, status_code=200)
+        params = {"version": REST_VERSION}
+        client.put(
+            f"orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb",
+            body={},
+            params=params,
+            use_rest=True,
+        )
+
+        assert (
+            requests_mock.last_request.headers["Content-Type"]
+            == "application/vnd.api+json"
+        )
+
+    def test_put_request_has_v1_content_type_when_specified(
+        self, requests_mock, client
+    ):
+        matcher = re.compile(
+            f"^{V1_URL}/org/{REST_ORG}/project/f9fec29a-d288-40d9-a019-cedf825e6efb$"
+        )
+        requests_mock.put(matcher, json={}, status_code=200)
+
+        client.put(
+            f"org/{REST_ORG}/project/f9fec29a-d288-40d9-a019-cedf825e6efb",
+            body={},
+            use_rest=False,
+        )
+
+        assert requests_mock.last_request.headers["Content-Type"] == "application/json"
 
     def test_delete_use_rest_when_specified(self, requests_mock, client):
         matcher = re.compile(

--- a/snyk/test_client.py
+++ b/snyk/test_client.py
@@ -391,13 +391,13 @@ class TestSnykClient(object):
 
         assert requests_mock.call_count == 1
 
-    def test_post_request_rest_api_when_specified(self, requests_mock, rest_client):
+    def test_post_request_rest_api_when_specified(self, requests_mock, client):
         matcher = re.compile(
             f"{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb\\?version={REST_VERSION}$"
         )
         requests_mock.post(matcher, json={}, status_code=200)
         params = {"version": REST_VERSION}
-        rest_client.post(
+        client.post(
             f"{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb",
             body={},
             params=params,
@@ -406,19 +406,48 @@ class TestSnykClient(object):
 
         assert requests_mock.call_count == 1
 
-    def test_put_request_rest_api_when_specified(self, requests_mock, rest_client):
+    def test_put_request_rest_api_when_specified(self, requests_mock, client):
         matcher = re.compile(
             f"{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb\\?version={REST_VERSION}$"
         )
         requests_mock.put(matcher, json={}, status_code=200)
         params = {"version": REST_VERSION}
-        rest_client.put(
+        client.put(
             f"{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb",
             body={},
             params=params,
             use_rest=True,
         )
 
+        assert requests_mock.call_count == 1
+
+    def test_put_request_v1_api_when_specified(self, requests_mock, client):
+        matcher = re.compile(
+            f"^https://api.snyk.io/v1/org/{REST_ORG}/project/f9fec29a-d288-40d9-a019-cedf825e6efb"
+        )
+        requests_mock.put(matcher, json={}, status_code=200)
+        client.put(
+            f"org/{REST_ORG}/project/f9fec29a-d288-40d9-a019-cedf825e6efb",
+            body={},
+            use_rest=False,
+        )
+
+        assert requests_mock.call_count == 1
+
+    def test_delete_use_rest_when_specified(self, requests_mock, client):
+        matcher = re.compile(
+            "^%s/orgs/%s\\?version=2[0-9]{3}-[0-9]{2}-[0-9]{2}$" % (REST_URL, REST_ORG)
+        )
+        requests_mock.delete(matcher, json={}, status_code=200)
+
+        client.delete(f"orgs/{REST_ORG}", use_rest=True)
+        assert requests_mock.call_count == 1
+
+    def test_delete_use_v1_when_specified(self, requests_mock, client):
+        matcher = re.compile("^%s/orgs/%s" % ("https://api.snyk.io/v1", REST_ORG))
+        requests_mock.delete(matcher, json={}, status_code=200)
+
+        client.delete(f"orgs/{REST_ORG}")
         assert requests_mock.call_count == 1
 
     def test_delete_redirects_to_rest_api_for_delete_project(

--- a/snyk/test_client.py
+++ b/snyk/test_client.py
@@ -347,7 +347,9 @@ class TestSnykClient(object):
         requests_mock.patch(matcher, json=project, status_code=200)
 
         response = rest_client.patch(
-            f"orgs/{REST_ORG}/projects/{project['id']}", body=project
+            f"orgs/{REST_ORG}/projects/{project['id']}",
+            body=project,
+            params={"expand": "target"},
         )
 
         response_data = response.json()

--- a/snyk/test_client.py
+++ b/snyk/test_client.py
@@ -19,6 +19,8 @@ V3_ORG = "39ddc762-b1b9-41ce-ab42-defbe4575bd6"
 V3_URL = "https://api.snyk.io/v3"
 V3_VERSION = "2022-02-16~experimental"
 
+V1_URL = "https://api.snyk.io/v1"
+
 
 class TestSnykClient(object):
     @pytest.fixture
@@ -405,6 +407,42 @@ class TestSnykClient(object):
         )
 
         assert requests_mock.call_count == 1
+
+    def test_post_request_has_rest_content_type_when_specified(
+        self, requests_mock, client
+    ):
+        matcher = re.compile(
+            f"{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb\\?version={REST_VERSION}$"
+        )
+        requests_mock.post(matcher, json={}, status_code=200)
+        params = {"version": REST_VERSION}
+        client.post(
+            f"{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb",
+            body={},
+            params=params,
+            use_rest=True,
+        )
+
+        assert (
+            requests_mock.last_request.headers["Content-Type"]
+            == "application/vnd.api+json"
+        )
+
+    def test_post_request_has_v1_content_type_when_specified(
+        self, requests_mock, client
+    ):
+        matcher = re.compile(
+            f"{V1_URL}/org/{REST_ORG}/project/f9fec29a-d288-40d9-a019-cedf825e6efb$"
+        )
+        requests_mock.post(matcher, json={}, status_code=200)
+
+        client.post(
+            f"{V1_URL}/org/{REST_ORG}/project/f9fec29a-d288-40d9-a019-cedf825e6efb",
+            body={},
+            use_rest=False,
+        )
+
+        assert requests_mock.last_request.headers["Content-Type"] == "application/json"
 
     def test_put_request_rest_api_when_specified(self, requests_mock, client):
         matcher = re.compile(

--- a/snyk/test_client.py
+++ b/snyk/test_client.py
@@ -368,3 +368,33 @@ class TestSnykClient(object):
             )
 
         assert requests_mock.call_count == 1
+
+    def test_post_request_rest_api(self, requests_mock, rest_client):
+        matcher = re.compile(
+            f"{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb\\?version={REST_VERSION}$"
+        )
+        requests_mock.post(matcher, json={}, status_code=200)
+        params = {"version": REST_VERSION}
+        rest_client.post(
+            f"{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb",
+            body={},
+            params=params,
+            use_rest=True,
+        )
+
+        assert requests_mock.call_count == 1
+
+    def test_put_request_rest_api(self, requests_mock, rest_client):
+        matcher = re.compile(
+            f"{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb\\?version={REST_VERSION}$"
+        )
+        requests_mock.put(matcher, json={}, status_code=200)
+        params = {"version": REST_VERSION}
+        rest_client.put(
+            f"{REST_URL}/orgs/{REST_ORG}/projects/f9fec29a-d288-40d9-a019-cedf825e6efb",
+            body={},
+            params=params,
+            use_rest=True,
+        )
+
+        assert requests_mock.call_count == 1

--- a/snyk/test_client.py
+++ b/snyk/test_client.py
@@ -13,7 +13,7 @@ TEST_DATA = os.path.join(os.path.dirname(__file__), "test_data")
 
 REST_ORG = "39ddc762-b1b9-41ce-ab42-defbe4575bd6"
 REST_URL = "https://api.snyk.io/rest"
-REST_VERSION = "2022-02-16~experimental"
+REST_VERSION = "2024-06-21"
 
 V3_ORG = "39ddc762-b1b9-41ce-ab42-defbe4575bd6"
 V3_URL = "https://api.snyk.io/v3"
@@ -207,9 +207,7 @@ class TestSnykClient(object):
 
     @pytest.fixture
     def rest_client(self):
-        return SnykClient(
-            "token", version="2022-02-16~experimental", url="https://api.snyk.io/rest"
-        )
+        return SnykClient("token", version="2024-06-21", url="https://api.snyk.io/rest")
 
     @pytest.fixture
     def v3_client(self):
@@ -329,3 +327,7 @@ class TestSnykClient(object):
         )
         params = {"limit": 10}
         rest_client.get(f"orgs/{REST_ORG}/projects?limit=100", params)
+
+    def test_patch_update_project_and_raises_error(self, requests_mock, rest_client):
+        matcher = "projects/f9fec29a-d288-40d9-a019-cedf825e6efb"
+        requests_mock.patch("")

--- a/snyk/test_client.py
+++ b/snyk/test_client.py
@@ -194,8 +194,8 @@ class TestSnykClient(object):
         matcher = re.compile("projects.*$")
         requests_mock.get(matcher, json=projects)
         assert (
-            "testing-new-name"
-            == client.projects.get("f9fec29a-d288-40d9-a019-cedf825e6efb").name
+                "testing-new-name"
+                == client.projects.get("f9fec29a-d288-40d9-a019-cedf825e6efb").name
         )
 
     def test_non_existent_project(self, requests_mock, client, organizations, projects):
@@ -259,12 +259,12 @@ class TestSnykClient(object):
         assert len(targets["data"]) == 10
 
     def test_get_v3_pages(
-        self,
-        requests_mock,
-        v3_client,
-        v3_targets_page1,
-        v3_targets_page2,
-        v3_targets_page3,
+            self,
+            requests_mock,
+            v3_client,
+            v3_targets_page1,
+            v3_targets_page2,
+            v3_targets_page3,
     ):
         requests_mock.get(
             f"{V3_URL}/orgs/{V3_ORG}/targets?limit=10&version={V3_VERSION}",
@@ -296,12 +296,12 @@ class TestSnykClient(object):
         assert len(targets["data"]) == 10
 
     def test_get_rest_pages(
-        self,
-        requests_mock,
-        rest_client,
-        rest_targets_page1,
-        rest_targets_page2,
-        rest_targets_page3,
+            self,
+            requests_mock,
+            rest_client,
+            rest_targets_page1,
+            rest_targets_page2,
+            rest_targets_page3,
     ):
         requests_mock.get(
             f"{REST_URL}/orgs/{REST_ORG}/targets?limit=10&version={REST_VERSION}",
@@ -328,6 +328,15 @@ class TestSnykClient(object):
         params = {"limit": 10}
         rest_client.get(f"orgs/{REST_ORG}/projects?limit=100", params)
 
-    def test_patch_update_project_and_raises_error(self, requests_mock, rest_client):
-        matcher = "projects/f9fec29a-d288-40d9-a019-cedf825e6efb"
-        requests_mock.patch("")
+    def test_patch_update_project_should_return_new_project(self, requests_mock, rest_client, projects):
+        matcher = re.compile("projects/f9fec29a-d288-40d9-a019-cedf825e6efb")
+        project = projects["data"][0]
+        project["attributes"]["tags"] = [{"key": "test_key", "value": "test_value"}]
+        project["attributes"]["environment"] = ["backend"]
+        project["attributes"]["lifecycle"] = ["development"]
+        requests_mock.patch(matcher, json=project, status_code=200)
+
+        response = rest_client.patch(f"orgs/{REST_ORG}/projects/{project['id']}", body=project)
+
+        assert response.status_code == 200
+        assert response.json()

--- a/snyk/test_client.py
+++ b/snyk/test_client.py
@@ -328,7 +328,7 @@ class TestSnykClient(object):
         params = {"limit": 10}
         rest_client.get(f"orgs/{REST_ORG}/projects?limit=100", params)
 
-    def test_patch_update_project_should_return_new_project(
+    def test_patch_update_project_should_return_updated_project(
         self, requests_mock, rest_client, projects
     ):
         project = projects["data"][0]

--- a/snyk/test_data/rest_targets_page1.json
+++ b/snyk/test_data/rest_targets_page1.json
@@ -115,6 +115,6 @@
     }
   ],
   "links": {
-    "next": "/orgs/39ddc762-b1b9-41ce-ab42-defbe4575bd6/targets?limit=10&version=2022-02-16~experimental&excludeEmpty=true&starting_after=v1.eyJpZCI6IjMyODE4ODAifQ%3D%3D"
+    "next": "/orgs/39ddc762-b1b9-41ce-ab42-defbe4575bd6/targets?limit=10&version=2024-06-21&excludeEmpty=true&starting_after=v1.eyJpZCI6IjMyODE4ODAifQ%3D%3D"
   }
 }

--- a/snyk/test_data/rest_targets_page2.json
+++ b/snyk/test_data/rest_targets_page2.json
@@ -115,7 +115,7 @@
     }
   ],
   "links": {
-    "next": "/orgs/39ddc762-b1b9-41ce-ab42-defbe4575bd6/targets?limit=10&version=2022-02-16~experimental&excludeEmpty=true&starting_after=v1.eyJpZCI6IjI5MTk1NjgifQ%3D%3D",
-    "prev": "/orgs/39ddc762-b1b9-41ce-ab42-defbe4575bd6/targets?limit=10&version=2022-02-16~experimental&excludeEmpty=true&ending_before=v1.eyJpZCI6IjMyODE4NzkifQ%3D%3D"
+    "next": "/orgs/39ddc762-b1b9-41ce-ab42-defbe4575bd6/targets?limit=10&version=2024-06-21&excludeEmpty=true&starting_after=v1.eyJpZCI6IjI5MTk1NjgifQ%3D%3D",
+    "prev": "/orgs/39ddc762-b1b9-41ce-ab42-defbe4575bd6/targets?limit=10&version=2024-06-21&excludeEmpty=true&ending_before=v1.eyJpZCI6IjMyODE4NzkifQ%3D%3D"
   }
 }

--- a/snyk/test_data/rest_targets_page3.json
+++ b/snyk/test_data/rest_targets_page3.json
@@ -115,6 +115,6 @@
     }
   ],
   "links": {
-    "prev": "/orgs/39ddc762-b1b9-41ce-ab42-defbe4575bd6/targets?limit=10&version=2022-02-16~experimental&excludeEmpty=true&ending_before=v1.eyJpZCI6IjMyODE4ODAifQ%3D%3D"
+    "prev": "/orgs/39ddc762-b1b9-41ce-ab42-defbe4575bd6/targets?limit=10&version=2024-06-21&excludeEmpty=true&ending_before=v1.eyJpZCI6IjMyODE4ODAifQ%3D%3D"
   }
 }

--- a/snyk/test_models.py
+++ b/snyk/test_models.py
@@ -24,8 +24,16 @@ class TestModels(object):
         return "https://api.snyk.io/v1"
 
     @pytest.fixture
+    def rest_base_url(self):
+        return "https://api.snyk.io/rest"
+
+    @pytest.fixture
     def organization_url(self, base_url, organization):
         return "%s/org/%s" % (base_url, organization.id)
+
+    @pytest.fixture
+    def organization_rest_url(self, rest_base_url, organization):
+        return "%s/orgs/%s" % (rest_base_url, organization.id)
 
 
 class TestOrganization(TestModels):
@@ -358,12 +366,16 @@ class TestProject(TestModels):
     def project_url(self, organization_url, project):
         return "%s/project/%s" % (organization_url, project.id)
 
-    def test_delete(self, project, project_url, requests_mock):
-        requests_mock.delete(project_url)
+    @pytest.fixture
+    def project_rest_url(self, organization_rest_url, project):
+        return "%s/projects/%s" % (organization_rest_url, project.id)
+
+    def test_delete(self, project, project_rest_url, requests_mock):
+        requests_mock.delete(project_rest_url)
         assert project.delete()
 
-    def test_failed_delete(self, project, project_url, requests_mock):
-        requests_mock.delete(project_url, status_code=500)
+    def test_failed_delete(self, project, project_rest_url, requests_mock):
+        requests_mock.delete(project_rest_url, status_code=500)
         with pytest.raises(SnykError):
             project.delete()
 

--- a/snyk/test_models.py
+++ b/snyk/test_models.py
@@ -46,28 +46,22 @@ class TestOrganization(TestModels):
     @pytest.fixture
     def project(self):
         return {
-            "data": {
-                "id": "6d5813be-7e6d-4ab8-80c2-1e3e2a454545",
-                "attributes": {
-                    "name": "atokeneduser/goof",
-                    "created": "2018-10-29T09:50:54.014Z",
-                    "origin": "cli",
-                    "type": "npm",
-                    "readOnly": "false",
-                    "testFrequency": "daily",
-                    "lastTestedDate": "2023-01-13T09:50:54.014Z",
-                    "isMonitored": "true",
-                    "tags": [{"key": "some-key", "value": "some-value"}],
-                },
-                "meta": {
-                    "latest_issue_counts": {
-                        "critical": 1,
-                        "low": 8,
-                        "high": 13,
-                        "medium": 15,
-                    }
-                },
-            }
+            "name": "atokeneduser/goof",
+            "id": "6d5813be-7e6d-4ab8-80c2-1e3e2a454545",
+            "created": "2018-10-29T09:50:54.014Z",
+            "origin": "cli",
+            "type": "npm",
+            "readOnly": "false",
+            "testFrequency": "daily",
+            "lastTestedDate": "2023-01-13T09:50:54.014Z",
+            "isMonitored": "true",
+            "issueCountsBySeverity": {
+                "critical": 1,
+                "low": 8,
+                "high": 13,
+                "medium": 15,
+            },
+            "tags": [{"key": "some-key", "value": "some-value"}],
         }
 
     @pytest.fixture
@@ -281,7 +275,7 @@ class TestOrganization(TestModels):
         assert organization.invite("example@example.com", admin=True)
 
     def test_get_project(self, organization, project, requests_mock):
-        matcher = re.compile("projects/6d5813be-7e6d-4ab8-80c2-1e3e2a454545")
+        matcher = re.compile("project/6d5813be-7e6d-4ab8-80c2-1e3e2a454545$")
         requests_mock.get(matcher, json=project)
         assert (
             "atokeneduser/goof"
@@ -291,7 +285,7 @@ class TestOrganization(TestModels):
     def test_get_project_organization_has_client(
         self, organization, project, requests_mock
     ):
-        matcher = re.compile("projects/6d5813be-7e6d-4ab8-80c2-1e3e2a454545")
+        matcher = re.compile("project/6d5813be-7e6d-4ab8-80c2-1e3e2a454545$")
         requests_mock.get(matcher, json=project)
         assert (
             organization.projects.get(
@@ -328,7 +322,7 @@ class TestOrganization(TestModels):
         assert organization.projects.filter() == []
 
     def test_tags_cache(self, organization, project, requests_mock):
-        matcher = re.compile("projects/6d5813be-7e6d-4ab8-80c2-1e3e2a454545")
+        matcher = re.compile("project/6d5813be-7e6d-4ab8-80c2-1e3e2a454545$")
         requests_mock.get(matcher, json=project)
         assert organization.projects.get(
             "6d5813be-7e6d-4ab8-80c2-1e3e2a454545"
@@ -337,7 +331,7 @@ class TestOrganization(TestModels):
     def test_get_organization_project_has_tags(
         self, organization, project, requests_mock
     ):
-        matcher = re.compile("projects/6d5813be-7e6d-4ab8-80c2-1e3e2a454545")
+        matcher = re.compile("project/6d5813be-7e6d-4ab8-80c2-1e3e2a454545$")
         requests_mock.get(matcher, json=project)
         assert organization.projects.get(
             "6d5813be-7e6d-4ab8-80c2-1e3e2a454545"

--- a/snyk/test_models.py
+++ b/snyk/test_models.py
@@ -46,22 +46,28 @@ class TestOrganization(TestModels):
     @pytest.fixture
     def project(self):
         return {
-            "name": "atokeneduser/goof",
-            "id": "6d5813be-7e6d-4ab8-80c2-1e3e2a454545",
-            "created": "2018-10-29T09:50:54.014Z",
-            "origin": "cli",
-            "type": "npm",
-            "readOnly": "false",
-            "testFrequency": "daily",
-            "lastTestedDate": "2023-01-13T09:50:54.014Z",
-            "isMonitored": "true",
-            "issueCountsBySeverity": {
-                "critical": 1,
-                "low": 8,
-                "high": 13,
-                "medium": 15,
-            },
-            "tags": [{"key": "some-key", "value": "some-value"}],
+            "data": {
+                "id": "6d5813be-7e6d-4ab8-80c2-1e3e2a454545",
+                "attributes": {
+                    "name": "atokeneduser/goof",
+                    "created": "2018-10-29T09:50:54.014Z",
+                    "origin": "cli",
+                    "type": "npm",
+                    "readOnly": "false",
+                    "testFrequency": "daily",
+                    "lastTestedDate": "2023-01-13T09:50:54.014Z",
+                    "isMonitored": "true",
+                    "tags": [{"key": "some-key", "value": "some-value"}],
+                },
+                "meta": {
+                    "latest_issue_counts": {
+                        "critical": 1,
+                        "low": 8,
+                        "high": 13,
+                        "medium": 15,
+                    }
+                }
+            }
         }
 
     @pytest.fixture
@@ -147,69 +153,62 @@ class TestOrganization(TestModels):
         assert organization.test_npm("snyk", "1.7.100")
 
     def test_pipfile_test_with_string(
-        self, organization, base_url, blank_test, requests_mock
+            self, organization, base_url, blank_test, requests_mock
     ):
         requests_mock.post("%s/test/pip" % base_url, json=blank_test)
         assert organization.test_pipfile("django==4.0.0")
 
     def test_pipfile_test_with_file(
-        self, organization, base_url, blank_test, fake_file, requests_mock
+            self, organization, base_url, blank_test, fake_file, requests_mock
     ):
         requests_mock.post("%s/test/pip" % base_url, json=blank_test)
         assert organization.test_pipfile(fake_file)
 
     def test_gemfilelock_test_with_file(
-        self, organization, base_url, blank_test, fake_file, requests_mock
+            self, organization, base_url, blank_test, fake_file, requests_mock
     ):
         requests_mock.post("%s/test/rubygems" % base_url, json=blank_test)
         assert organization.test_gemfilelock(fake_file)
 
     def test_packagejson_test_with_file(
-        self, organization, base_url, blank_test, fake_file, requests_mock
+            self, organization, base_url, blank_test, fake_file, requests_mock
     ):
-
         requests_mock.post("%s/test/npm" % base_url, json=blank_test)
         assert organization.test_packagejson(fake_file)
 
     def test_packagejson_test_with_files(
-        self, organization, base_url, blank_test, fake_file, requests_mock
+            self, organization, base_url, blank_test, fake_file, requests_mock
     ):
-
         requests_mock.post("%s/test/npm" % base_url, json=blank_test)
         assert organization.test_packagejson(fake_file, fake_file)
 
     def test_gradlefile_test_with_file(
-        self, organization, base_url, blank_test, fake_file, requests_mock
+            self, organization, base_url, blank_test, fake_file, requests_mock
     ):
-
         requests_mock.post("%s/test/gradle" % base_url, json=blank_test)
         assert organization.test_gradlefile(fake_file)
 
     def test_sbt_test_with_file(
-        self, organization, base_url, blank_test, fake_file, requests_mock
+            self, organization, base_url, blank_test, fake_file, requests_mock
     ):
-
         requests_mock.post("%s/test/sbt" % base_url, json=blank_test)
         assert organization.test_sbt(fake_file)
 
     def test_pom_test_with_file(
-        self, organization, base_url, blank_test, fake_file, requests_mock
+            self, organization, base_url, blank_test, fake_file, requests_mock
     ):
-
         requests_mock.post("%s/test/maven" % base_url, json=blank_test)
         assert organization.test_pom(fake_file)
 
     def test_composer_with_files(
-        self, organization, base_url, blank_test, fake_file, requests_mock
+            self, organization, base_url, blank_test, fake_file, requests_mock
     ):
-
         requests_mock.post("%s/test/composer" % base_url, json=blank_test)
         assert organization.test_composer(fake_file, fake_file)
 
     def test_yarn_with_files(
-        self, organization, base_url, blank_test, fake_file, requests_mock
+            self, organization, base_url, blank_test, fake_file, requests_mock
     ):
-
         requests_mock.post("%s/test/yarn" % base_url, json=blank_test)
         assert organization.test_yarn(fake_file, fake_file)
 
@@ -282,23 +281,23 @@ class TestOrganization(TestModels):
         assert organization.invite("example@example.com", admin=True)
 
     def test_get_project(self, organization, project, requests_mock):
-        matcher = re.compile("project/6d5813be-7e6d-4ab8-80c2-1e3e2a454545$")
+        matcher = re.compile("projects/6d5813be-7e6d-4ab8-80c2-1e3e2a454545")
         requests_mock.get(matcher, json=project)
         assert (
-            "atokeneduser/goof"
-            == organization.projects.get("6d5813be-7e6d-4ab8-80c2-1e3e2a454545").name
+                "atokeneduser/goof"
+                == organization.projects.get("6d5813be-7e6d-4ab8-80c2-1e3e2a454545").name
         )
 
     def test_get_project_organization_has_client(
-        self, organization, project, requests_mock
+            self, organization, project, requests_mock
     ):
-        matcher = re.compile("project/6d5813be-7e6d-4ab8-80c2-1e3e2a454545$")
+        matcher = re.compile("projects/6d5813be-7e6d-4ab8-80c2-1e3e2a454545")
         requests_mock.get(matcher, json=project)
         assert (
-            organization.projects.get(
-                "6d5813be-7e6d-4ab8-80c2-1e3e2a454545"
-            ).organization.client
-            is not None
+                organization.projects.get(
+                    "6d5813be-7e6d-4ab8-80c2-1e3e2a454545"
+                ).organization.client
+                is not None
         )
 
     def test_filter_projects_by_tag_missing_value(self, organization, requests_mock):
@@ -329,16 +328,16 @@ class TestOrganization(TestModels):
         assert organization.projects.filter() == []
 
     def test_tags_cache(self, organization, project, requests_mock):
-        matcher = re.compile("project/6d5813be-7e6d-4ab8-80c2-1e3e2a454545$")
+        matcher = re.compile("projects/6d5813be-7e6d-4ab8-80c2-1e3e2a454545")
         requests_mock.get(matcher, json=project)
         assert organization.projects.get(
             "6d5813be-7e6d-4ab8-80c2-1e3e2a454545"
         )._tags == [{"key": "some-key", "value": "some-value"}]
 
     def test_get_organization_project_has_tags(
-        self, organization, project, requests_mock
+            self, organization, project, requests_mock
     ):
-        matcher = re.compile("project/6d5813be-7e6d-4ab8-80c2-1e3e2a454545$")
+        matcher = re.compile("projects/6d5813be-7e6d-4ab8-80c2-1e3e2a454545")
         requests_mock.get(matcher, json=project)
         assert organization.projects.get(
             "6d5813be-7e6d-4ab8-80c2-1e3e2a454545"
@@ -447,13 +446,13 @@ class TestProject(TestModels):
             project.ignores.get("not-present")
 
     def test_filter_not_implemented_on_dict_managers(
-        self, project, project_url, requests_mock
+            self, project, project_url, requests_mock
     ):
         with pytest.raises(SnykNotImplementedError):
             project.ignores.filter(key="value")
 
     def test_first_fails_on_empty_dict_managers(
-        self, project, project_url, requests_mock
+            self, project, project_url, requests_mock
     ):
         requests_mock.get("%s/ignores" % project_url, json={})
         with pytest.raises(SnykNotFoundError):
@@ -661,7 +660,7 @@ class TestProject(TestModels):
         assert expected == project.vulnerabilities
 
     def test_aggregated_issues_missing_optional_fields(
-        self, project, project_url, requests_mock
+            self, project, project_url, requests_mock
     ):
         requests_mock.post(
             "%s/aggregated-issues" % project_url,
@@ -763,7 +762,7 @@ class TestProject(TestModels):
         assert project.issueset.filter(ignored=True).ok
 
     def test_filtering_empty_issues_aggregated(
-        self, project, project_url, requests_mock
+            self, project, project_url, requests_mock
     ):
         requests_mock.post(
             "%s/aggregated-issues" % project_url,
@@ -791,7 +790,7 @@ class TestProject(TestModels):
         assert [] == project.licenses.all()
 
     def test_empty_license_severity(
-        self, organization, organization_url, requests_mock
+            self, organization, organization_url, requests_mock
     ):
         requests_mock.post(
             "%s/licenses" % organization_url,
@@ -821,7 +820,7 @@ class TestProject(TestModels):
         assert licenses.severity is None
 
     def test_missing_package_version_in_dep_graph(
-        self, project, project_url, requests_mock
+            self, project, project_url, requests_mock
     ):
         requests_mock.get(
             "%s/dep-graph" % project_url,

--- a/snyk/test_models.py
+++ b/snyk/test_models.py
@@ -66,7 +66,7 @@ class TestOrganization(TestModels):
                         "high": 13,
                         "medium": 15,
                     }
-                }
+                },
             }
         }
 
@@ -153,61 +153,61 @@ class TestOrganization(TestModels):
         assert organization.test_npm("snyk", "1.7.100")
 
     def test_pipfile_test_with_string(
-            self, organization, base_url, blank_test, requests_mock
+        self, organization, base_url, blank_test, requests_mock
     ):
         requests_mock.post("%s/test/pip" % base_url, json=blank_test)
         assert organization.test_pipfile("django==4.0.0")
 
     def test_pipfile_test_with_file(
-            self, organization, base_url, blank_test, fake_file, requests_mock
+        self, organization, base_url, blank_test, fake_file, requests_mock
     ):
         requests_mock.post("%s/test/pip" % base_url, json=blank_test)
         assert organization.test_pipfile(fake_file)
 
     def test_gemfilelock_test_with_file(
-            self, organization, base_url, blank_test, fake_file, requests_mock
+        self, organization, base_url, blank_test, fake_file, requests_mock
     ):
         requests_mock.post("%s/test/rubygems" % base_url, json=blank_test)
         assert organization.test_gemfilelock(fake_file)
 
     def test_packagejson_test_with_file(
-            self, organization, base_url, blank_test, fake_file, requests_mock
+        self, organization, base_url, blank_test, fake_file, requests_mock
     ):
         requests_mock.post("%s/test/npm" % base_url, json=blank_test)
         assert organization.test_packagejson(fake_file)
 
     def test_packagejson_test_with_files(
-            self, organization, base_url, blank_test, fake_file, requests_mock
+        self, organization, base_url, blank_test, fake_file, requests_mock
     ):
         requests_mock.post("%s/test/npm" % base_url, json=blank_test)
         assert organization.test_packagejson(fake_file, fake_file)
 
     def test_gradlefile_test_with_file(
-            self, organization, base_url, blank_test, fake_file, requests_mock
+        self, organization, base_url, blank_test, fake_file, requests_mock
     ):
         requests_mock.post("%s/test/gradle" % base_url, json=blank_test)
         assert organization.test_gradlefile(fake_file)
 
     def test_sbt_test_with_file(
-            self, organization, base_url, blank_test, fake_file, requests_mock
+        self, organization, base_url, blank_test, fake_file, requests_mock
     ):
         requests_mock.post("%s/test/sbt" % base_url, json=blank_test)
         assert organization.test_sbt(fake_file)
 
     def test_pom_test_with_file(
-            self, organization, base_url, blank_test, fake_file, requests_mock
+        self, organization, base_url, blank_test, fake_file, requests_mock
     ):
         requests_mock.post("%s/test/maven" % base_url, json=blank_test)
         assert organization.test_pom(fake_file)
 
     def test_composer_with_files(
-            self, organization, base_url, blank_test, fake_file, requests_mock
+        self, organization, base_url, blank_test, fake_file, requests_mock
     ):
         requests_mock.post("%s/test/composer" % base_url, json=blank_test)
         assert organization.test_composer(fake_file, fake_file)
 
     def test_yarn_with_files(
-            self, organization, base_url, blank_test, fake_file, requests_mock
+        self, organization, base_url, blank_test, fake_file, requests_mock
     ):
         requests_mock.post("%s/test/yarn" % base_url, json=blank_test)
         assert organization.test_yarn(fake_file, fake_file)
@@ -284,20 +284,20 @@ class TestOrganization(TestModels):
         matcher = re.compile("projects/6d5813be-7e6d-4ab8-80c2-1e3e2a454545")
         requests_mock.get(matcher, json=project)
         assert (
-                "atokeneduser/goof"
-                == organization.projects.get("6d5813be-7e6d-4ab8-80c2-1e3e2a454545").name
+            "atokeneduser/goof"
+            == organization.projects.get("6d5813be-7e6d-4ab8-80c2-1e3e2a454545").name
         )
 
     def test_get_project_organization_has_client(
-            self, organization, project, requests_mock
+        self, organization, project, requests_mock
     ):
         matcher = re.compile("projects/6d5813be-7e6d-4ab8-80c2-1e3e2a454545")
         requests_mock.get(matcher, json=project)
         assert (
-                organization.projects.get(
-                    "6d5813be-7e6d-4ab8-80c2-1e3e2a454545"
-                ).organization.client
-                is not None
+            organization.projects.get(
+                "6d5813be-7e6d-4ab8-80c2-1e3e2a454545"
+            ).organization.client
+            is not None
         )
 
     def test_filter_projects_by_tag_missing_value(self, organization, requests_mock):
@@ -335,7 +335,7 @@ class TestOrganization(TestModels):
         )._tags == [{"key": "some-key", "value": "some-value"}]
 
     def test_get_organization_project_has_tags(
-            self, organization, project, requests_mock
+        self, organization, project, requests_mock
     ):
         matcher = re.compile("projects/6d5813be-7e6d-4ab8-80c2-1e3e2a454545")
         requests_mock.get(matcher, json=project)
@@ -446,13 +446,13 @@ class TestProject(TestModels):
             project.ignores.get("not-present")
 
     def test_filter_not_implemented_on_dict_managers(
-            self, project, project_url, requests_mock
+        self, project, project_url, requests_mock
     ):
         with pytest.raises(SnykNotImplementedError):
             project.ignores.filter(key="value")
 
     def test_first_fails_on_empty_dict_managers(
-            self, project, project_url, requests_mock
+        self, project, project_url, requests_mock
     ):
         requests_mock.get("%s/ignores" % project_url, json={})
         with pytest.raises(SnykNotFoundError):
@@ -660,7 +660,7 @@ class TestProject(TestModels):
         assert expected == project.vulnerabilities
 
     def test_aggregated_issues_missing_optional_fields(
-            self, project, project_url, requests_mock
+        self, project, project_url, requests_mock
     ):
         requests_mock.post(
             "%s/aggregated-issues" % project_url,
@@ -762,7 +762,7 @@ class TestProject(TestModels):
         assert project.issueset.filter(ignored=True).ok
 
     def test_filtering_empty_issues_aggregated(
-            self, project, project_url, requests_mock
+        self, project, project_url, requests_mock
     ):
         requests_mock.post(
             "%s/aggregated-issues" % project_url,
@@ -790,7 +790,7 @@ class TestProject(TestModels):
         assert [] == project.licenses.all()
 
     def test_empty_license_severity(
-            self, organization, organization_url, requests_mock
+        self, organization, organization_url, requests_mock
     ):
         requests_mock.post(
             "%s/licenses" % organization_url,
@@ -820,7 +820,7 @@ class TestProject(TestModels):
         assert licenses.severity is None
 
     def test_missing_package_version_in_dep_graph(
-            self, project, project_url, requests_mock
+        self, project, project_url, requests_mock
     ):
         requests_mock.get(
             "%s/dep-graph" % project_url,


### PR DESCRIPTION
### Description of changes
In this modification, I created the opportunity for users to decide between using v1 api or rest api route in the `SnykClient`. Previously, only the get method let user to use the rest api. Patch method was created for use cases in which the verb PATCH is necessary, thing that didn't exist previously.

### Technical details

- added patch method in the `SnykClient` class.
- updated old tests and added new test cases for the new modifications.
- redirect delete project from v1 to rest in the client.
- updated rest api version, because some endpoints were not available in the old version.

### Context
These changes were made to enable users use the rest api, because v1 is approaching its end of life. It provides more flexibility to the developers who wants to interact with different instances of Snyk APIs.

### How to test
This modification should not impact the existing functionality of the library. Everything should work as intended.

### Example Usage
Update an existing project
```python
client = SnykClient(token=api_key)
client.patch(
    f"orgs/org_id/projects/project_id",
    body={
        "data": {
            "attributes": {
                "business_criticality": ["critical", "medium", "low"],
                "tags": [
                    {"key": "keytest1", "value": "valuetest1"},
                    {"key": "keytest2", "value": "valuetest2"},
                ],
                "environment": ["backend", "frontend"],
                "lifecycle": ["development"],
            },
            "id": "project_id",
            "relationships": {},
            "type": "project",
        }
    },
)
