### PR TITLE
docs: remove deprecated v3 apis

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ Getting the rest information of an organization:
 # To get this value, get it from a Snyk organizations settings page
 snyk_org = "df734bed-d75c-4f11-bb47-1d119913bcc7"
 
-# to use the rest endpoint you MUST include a version value and the url of the v3 api endpoint as shown below
+# to use the rest endpoint you MUST include a version value and the url of the rest api endpoint as shown below
 rest_client = SnykClient(snyk_token, version="2022-02-16~experimental", url="https://api.snyk.io/rest")
 
 print(rest_client.get(f"/orgs/{snyk_org}").json())
@@ -252,7 +252,7 @@ v1_org = v1client.organizations.get(snyk_org)
 rest_org = rest_client.get(f"/orgs/{snyk_org}").json()
 ```
 
-The rest API introduces consistent pagination across all endpoints. The v3 client includes a helper method `.get_rest_pages` which collects the paginated responses and returns a single list combining the contents of the "data" key from all pages. It takes the same values as the get method.
+The rest API introduces consistent pagination across all endpoints. The rest client includes a helper method `.get_rest_pages` which collects the paginated responses and returns a single list combining the contents of the "data" key from all pages. It takes the same values as the get method.
 
 ```python
 rest_client = SnykClient(snyk_token, version="2022-02-16~experimental", url="https://api.snyk.io/rest")

--- a/snyk/test_client.py
+++ b/snyk/test_client.py
@@ -15,10 +15,6 @@ REST_ORG = "39ddc762-b1b9-41ce-ab42-defbe4575bd6"
 REST_URL = "https://api.snyk.io/rest"
 REST_VERSION = "2022-02-16~experimental"
 
-V3_ORG = "39ddc762-b1b9-41ce-ab42-defbe4575bd6"
-V3_URL = "https://api.snyk.io/v3"
-V3_VERSION = "2022-02-16~experimental"
-
 
 class TestSnykClient(object):
     @pytest.fixture
@@ -212,28 +208,6 @@ class TestSnykClient(object):
         )
 
     @pytest.fixture
-    def v3_client(self):
-        return SnykClient(
-            "token", version="2022-02-16~experimental", url="https://api.snyk.io/v3"
-        )
-
-    @pytest.fixture
-    def v3_groups(self):
-        return load_test_data(TEST_DATA, "v3_groups")
-
-    @pytest.fixture
-    def v3_targets_page1(self):
-        return load_test_data(TEST_DATA, "v3_targets_page1")
-
-    @pytest.fixture
-    def v3_targets_page2(self):
-        return load_test_data(TEST_DATA, "v3_targets_page2")
-
-    @pytest.fixture
-    def v3_targets_page3(self):
-        return load_test_data(TEST_DATA, "v3_targets_page3")
-
-    @pytest.fixture
     def rest_groups(self):
         return load_test_data(TEST_DATA, "rest_groups")
 
@@ -248,43 +222,6 @@ class TestSnykClient(object):
     @pytest.fixture
     def rest_targets_page3(self):
         return load_test_data(TEST_DATA, "rest_targets_page3")
-
-    def test_v3get(self, requests_mock, v3_client, v3_targets_page1):
-        requests_mock.get(
-            f"{V3_URL}/orgs/{V3_ORG}/targets?limit=10&version={V3_VERSION}",
-            json=v3_targets_page1,
-        )
-        t_params = {"limit": 10}
-
-        targets = v3_client.get(f"orgs/{V3_ORG}/targets", t_params).json()
-
-        assert len(targets["data"]) == 10
-
-    def test_get_v3_pages(
-        self,
-        requests_mock,
-        v3_client,
-        v3_targets_page1,
-        v3_targets_page2,
-        v3_targets_page3,
-    ):
-        requests_mock.get(
-            f"{V3_URL}/orgs/{V3_ORG}/targets?limit=10&version={V3_VERSION}",
-            json=v3_targets_page1,
-        )
-        requests_mock.get(
-            f"{V3_URL}/orgs/{V3_ORG}/targets?limit=10&version={V3_VERSION}&excludeEmpty=true&starting_after=v1.eyJpZCI6IjMyODE4ODAifQ%3D%3D",
-            json=v3_targets_page2,
-        )
-        requests_mock.get(
-            f"{V3_URL}/orgs/{V3_ORG}/targets?limit=10&version={V3_VERSION}&excludeEmpty=true&starting_after=v1.eyJpZCI6IjI5MTk1NjgifQ%3D%3D",
-            json=v3_targets_page3,
-        )
-        t_params = {"limit": 10}
-
-        data = v3_client.get_v3_pages(f"orgs/{V3_ORG}/targets", t_params)
-
-        assert len(data) == 30
 
     def test_rest_get(self, requests_mock, rest_client, rest_targets_page1):
         requests_mock.get(
@@ -319,7 +256,7 @@ class TestSnykClient(object):
         )
         t_params = {"limit": 10}
 
-        data = rest_client.get_rest_pages(f"orgs/{V3_ORG}/targets", t_params)
+        data = rest_client.get_rest_pages(f"orgs/{REST_ORG}/targets", t_params)
 
         assert len(data) == 30
 


### PR DESCRIPTION
Removes references to V3 APIs as they have been replaced by REST equivalents 3 years ago.